### PR TITLE
Use DynamicMvvmConfiguration.LoggerFactory everywhere to get logger 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 [#09] Update Android target to 10.0
+[#10] Update the source of the `ViewModelBase` private `ILogger` instance.
 
 ### Deprecated
 

--- a/src/DynamicMvvm.Abstractions/Command/IDynamicCommand.md
+++ b/src/DynamicMvvm.Abstractions/Command/IDynamicCommand.md
@@ -176,7 +176,7 @@ You can decorate all commands created from the `IDynamicCommandFactory` by using
 // This will create a new IDynamicCommand using a IDynamicCommandFactory
 var myCommandDecorator = new DynamicCommandStrategyDecorator(c => c
   // This will add logs your commands.
-  .WithLogs(s.GetRequiredService<ILogger<IDynamicCommand>>())
+  .WithLogs()
 
   // This will catch any errors unhandled by your commands.
   .CatchErrors(HandleCommandError)

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
@@ -197,9 +197,7 @@ namespace Chinook.DynamicMvvm
 		{
 			if (!viewModel.TryGetDisposable<IDynamicProperty>(name, out var property))
 			{
-				var logger = (ILogger)viewModel.ServiceProvider.GetService<ILogger<IViewModel>>() ?? NullLogger.Instance;
-
-				logger.Log(LogLevel.Warning, "Resolving a property using reflection.");
+				typeof(IViewModel).Log().LogWarning($"Resolving property {viewModel.Name}.{name} using reflection.");
 
 				// This is a rare case where the property was resolved before being created.
 				// We simply resolve it manually on the type.

--- a/src/DynamicMvvm/Command/Strategies/LoggerCommandStrategy.cs
+++ b/src/DynamicMvvm/Command/Strategies/LoggerCommandStrategy.cs
@@ -13,10 +13,10 @@ namespace Chinook.DynamicMvvm
 		/// Will add logs to the command execution.
 		/// </summary>
 		/// <param name="innerStrategy"><see cref="IDynamicCommandStrategy"/></param>
-		/// <param name="logger"><see cref="ILogger"/></param>
+		/// <param name="logger">Optional; the desired logger. If null is passed, a new one will be created using <see cref="DynamicMvvmConfiguration.LoggerFactory"/>.</param>
 		/// <returns><see cref="IDynamicCommandStrategy"/></returns>
-		public static IDynamicCommandStrategy WithLogs(this IDynamicCommandStrategy innerStrategy, ILogger logger)
-			=> new LoggerCommandStrategy(innerStrategy, logger);
+		public static IDynamicCommandStrategy WithLogs(this IDynamicCommandStrategy innerStrategy, ILogger logger = null)
+			=> new LoggerCommandStrategy(innerStrategy, logger ?? typeof(IDynamicCommand).Log());
 	}
 
 	/// <summary>

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.cs
@@ -25,7 +25,7 @@ namespace Chinook.DynamicMvvm
 			Name = name ?? GetType().Name;
 			ServiceProvider = serviceProvider ?? DefaultServiceProvider;
 
-			_logger = (ILogger)ServiceProvider?.GetService<ILogger<ViewModelBase>>() ?? NullLogger.Instance;
+			_logger = typeof(ViewModelBase).Log();
 
 			if (_diagnostics.IsEnabled("Created"))
 			{


### PR DESCRIPTION
## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- `ViewModelBase` uses the `ServiceProvider` to get its logger.
- The `ILogger` parameters of the `IDynamicCommandStrategy.WithLogs()` is not optional.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- `ViewModelBase` uses `DynamicMvvmConfiguration.LoggerFactory` to get its logger.
- The `ILogger` parameters of the `IDynamicCommandStrategy.WithLogs()` is optional.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

