### PR TITLE
fix: ViewModelBase now throws when used after having been disposed.

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -27,6 +27,8 @@ namespace Chinook.DynamicMvvm
 			key = key ?? throw new ArgumentNullException(nameof(key));
 			disposable = disposable ?? throw new ArgumentNullException(nameof(disposable));
 
+			ThrowIfDisposed();
+
 			_disposables.Add(key, disposable);
 		}
 
@@ -41,6 +43,8 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
+			ThrowIfDisposed();
+
 			_disposables.Remove(key);
 		}
 
@@ -49,7 +53,17 @@ namespace Chinook.DynamicMvvm
 		{
 			key = key ?? throw new ArgumentNullException(nameof(key));
 
+			ThrowIfDisposed();
+
 			return _disposables.TryGetValue(key, out disposable);
+		}
+
+		private void ThrowIfDisposed()
+		{
+			if (_isDisposed)
+			{
+				throw new ObjectDisposedException($"The ViewModel {Name} is disposed.");
+			}
 		}
 
 		/// <inheritdoc />
@@ -75,6 +89,7 @@ namespace Chinook.DynamicMvvm
 					}
 				}
 
+				_view.SetTarget(null);
 				_disposables.Clear();
 			}
 

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
@@ -40,6 +40,8 @@ namespace Chinook.DynamicMvvm
 		/// <inheritdoc />
 		public void SetErrors(string propertyName, IEnumerable<object> errors)
 		{
+			ThrowIfDisposed();
+
 			_errors[propertyName] = errors;
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
@@ -48,6 +50,8 @@ namespace Chinook.DynamicMvvm
 		/// <inheritdoc />
 		public void SetErrors(IDictionary<string, IEnumerable<object>> errors)
 		{
+			ThrowIfDisposed();
+
 			_errors = new ConcurrentDictionary<string, IEnumerable<object>>(errors);
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName: null));
@@ -56,6 +60,8 @@ namespace Chinook.DynamicMvvm
 		/// <inheritdoc />
 		public void ClearErrors(string propertyName = null)
 		{
+			ThrowIfDisposed();
+
 			if (string.IsNullOrEmpty(propertyName))
 			{
 				_errors.Clear();

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -12,6 +12,8 @@ namespace Chinook.DynamicMvvm
 		/// <inheritdoc />
 		public void RaisePropertyChanged(string propertyName)
 		{
+			ThrowIfDisposed();
+
 			if (PropertyChanged == null)
 			{
 				return;

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.View.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.View.cs
@@ -27,6 +27,12 @@ namespace Chinook.DynamicMvvm
 
 		private void SetView(IViewModelView view)
 		{
+			if (view != null)
+			{
+				// When the VM is disposed, we don't want to throw when setting a null view.
+				ThrowIfDisposed();
+			}
+
 			_view.SetTarget(view);
 
 			ViewChanged?.Invoke(view);


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

ViewModelBase can still be used once it's been disposed.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

ViewModelBase now throws ObjectDisposedException when we try to mutate it after it's been disposed.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

