### PR TITLE
Implemented new IViewModelExtension AttachOrReplaceChild

### DIFF
--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
@@ -127,6 +127,29 @@ namespace Chinook.DynamicMvvm
 			viewModel.RemoveDisposable(name ?? childViewModel.Name);
 		}
 
+		/// <summary>
+		/// Attaches a child <see cref="IViewModel"/> to a parent <see cref="IViewModel"/>.
+		/// If the child has already been attached, the newer instance will be attached instead of the previous instance.
+		/// By being attached, the child will be disposed when the parent is disposed.
+		/// Both also share the same <see cref="IViewModelView"/>.
+		/// </summary>
+		/// <remarks>The previous instance will be disposed when replaced.</remarks>
+		/// <param name="viewModel">The parent <see cref="IViewModel"/>.</param>
+		/// <param name="childViewModel">The child <see cref="IViewModel"/> to detach.</param>
+		/// <param name="name">The child ViewModel's name. This defaults to <paramref name="childViewModel"/>.Name when not provided.</param>
+		public static TChildViewModel AttachOrReplaceChild<TChildViewModel>(this IViewModel viewModel, TChildViewModel childViewModel, string name = null)
+			where TChildViewModel : IViewModel
+		{
+			name = name ?? childViewModel.Name;
+
+			if (viewModel.TryGetDisposable(name, out var instance))
+			{
+				viewModel.DetachChild((IViewModel)instance, name);
+				instance.Dispose();
+			}
+			return viewModel.AttachChild(childViewModel, name);
+		}
+
 		private class ParentViewChangedDisposable : IDisposable
 		{
 			private IViewModel _parentViewModel;

--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
@@ -178,5 +178,70 @@ namespace Chinook.DynamicMvvm.Tests.ViewModel
 
 			Assert.Throws<InvalidOperationException>(() => parentViewModel.AttachChild(childViewModel2));
 		}
+
+		[Fact]
+		public void It_Attaches_Child_When_AttachOrReplaceChild()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel = new ViewModelBase();
+
+			parentViewModel.AttachOrReplaceChild(childViewModel);
+
+			parentViewModel.GetChildren().Should().Contain(childViewModel);
+		}
+
+		[Fact]
+		public void It_Replaces_PreviousChild_And_Attaches_NewChild_When_AttachOrReplaceChild_With_Same_Name()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel1 = new ViewModelBase();
+			var childViewModel2 = new ViewModelBase();
+
+			parentViewModel.AttachOrReplaceChild(childViewModel1, "Child1");
+			parentViewModel.AttachOrReplaceChild(childViewModel2, "Child1");
+
+			parentViewModel.GetChildren().Should().NotContain(childViewModel1);
+			parentViewModel.GetChildren().Should().Contain(childViewModel2);
+		}
+
+		[Fact]
+		public void It_Replaces_PreviousChild_And_Attaches_NewChild_When_AttachOrReplaceChild_With_Same_Name_From_ViewModel()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel1 = new ViewModelBase("Child1");
+			var childViewModel2 = new ViewModelBase("Child1");
+
+			parentViewModel.AttachOrReplaceChild(childViewModel1);
+			parentViewModel.AttachOrReplaceChild(childViewModel2);
+
+			parentViewModel.GetChildren().Should().NotContain(childViewModel1);
+			parentViewModel.GetChildren().Should().Contain(childViewModel2);
+		}
+
+		[Fact]
+		public void It_Dispose_PreviousChild_When_AttachOrReplaceChild_With_Same_Name()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel1 = new ViewModelBase();
+			var childViewModel2 = new ViewModelBase();
+
+			parentViewModel.AttachOrReplaceChild(childViewModel1, "Child1");
+			parentViewModel.AttachOrReplaceChild(childViewModel2, "Child1");
+
+			Assert.Throws<ObjectDisposedException>(() => childViewModel1.SetErrors(string.Empty, Array.Empty<object>()));
+		}
+
+		[Fact]
+		public void It_Dispose_PreviousChild_When_AttachOrReplaceChild_With_Same_Name_From_ViewModel()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel1 = new ViewModelBase("Child1");
+			var childViewModel2 = new ViewModelBase("Child1");
+
+			parentViewModel.AttachOrReplaceChild(childViewModel1);
+			parentViewModel.AttachOrReplaceChild(childViewModel2);
+
+			Assert.Throws<ObjectDisposedException>(() => childViewModel1.SetErrors(string.Empty, Array.Empty<object>()));
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
Currently, when we try to attach again a child (with the same name) on a parent ViewModel, it will throws an exception. 

## What is the new behavior?
Now, if you use the extension method AttachOrReplaceChild, it will detach the previous instance (and disposed it) and attach the new instance to the parent ViewModel.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

