### PR TITLE
fix: Improve ViewModelBase behavior when disposed

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.4.0
+next-version: 0.5.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
@@ -32,13 +32,18 @@ namespace Chinook.DynamicMvvm
 		/// <param name="viewModel">The parent <see cref="IViewModel"/>.</param>
 		/// <param name="childViewModelProvider">The factory to the child <see cref="IViewModel"/>.</param>
 		/// <param name="name">The child ViewModel's name.</param>
-		/// <returns>The attached child <see cref="IViewModel"/>.</returns>
+		/// <returns>The attached child <see cref="IViewModel"/>. Default of <typeparamref name="TChildViewModel"/> is returned if the <see cref="IViewModel"/> is disposed.</returns>
 		public static TChildViewModel GetChild<TChildViewModel>(
 			this IViewModel viewModel,
 			Func<TChildViewModel> childViewModelProvider,
 			[CallerMemberName] string name = null
 		) where TChildViewModel : IViewModel
 		{
+			if (viewModel.IsDisposed)
+			{
+				return default(TChildViewModel);
+			}
+
 			if (!viewModel.TryGetDisposable<TChildViewModel>(name, out var childViewModel))
 			{
 				childViewModel = viewModel.AttachChild(childViewModelProvider(), name);

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Commands.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Commands.cs
@@ -86,7 +86,7 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">The command name.</param>
 		/// <param name="factory">The command factory.</param>
 		/// <param name="configure">The optional function to configure the command builder.</param>
-		/// <returns>The attached <see cref="IDynamicCommand"/>.</returns>
+		/// <returns>The attached <see cref="IDynamicCommand"/>. Null is returned if the <see cref="IViewModel"/> is disposed.</returns>
 		public static IDynamicCommand GetOrCreateCommand(
 			this IViewModel viewModel,
 			string name,
@@ -94,6 +94,11 @@ namespace Chinook.DynamicMvvm
 			Func<IDynamicCommandBuilder, IDynamicCommandBuilder> configure = null
 		)
 		{
+			if (viewModel.IsDisposed)
+			{
+				return null;
+			}
+
 			if (!viewModel.TryGetDisposable<IDynamicCommand>(name, out var command))
 			{
 				var builder = factory(name);

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.cs
@@ -93,5 +93,10 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="propertyName">The property name.</param>
 		void ClearErrors(string propertyName = null);
+
+		/// <summary>
+		/// Gets whether this <see cref="IViewModel"/> is disposed.
+		/// </summary>
+		bool IsDisposed { get; }
 	}
 }

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModelView.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModelView.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Chinook.DynamicMvvm
 {
 	/// <summary>
 	/// A <see cref="IViewModelView"/> represents the view contract of a <see cref="IViewModel"/>.
 	/// </summary>
-	public interface IViewModelView
+	public interface IViewModelView : IDisposable
 	{
 		/// <summary>
 		/// Gets whether or not the thread has dispatcher access.
@@ -28,6 +30,6 @@ namespace Chinook.DynamicMvvm
 		/// Executes the specified action on a dispatcher thread.
 		/// </summary>
 		/// <param name="action">The action to execute.</param>
-		void ExecuteOnDispatcher(Action action);
+		Task ExecuteOnDispatcher(Action action);
 	}
 }

--- a/src/DynamicMvvm.Tests/Helpers/TestViewModelView.cs
+++ b/src/DynamicMvvm.Tests/Helpers/TestViewModelView.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chinook.DynamicMvvm.Tests.Helpers
@@ -25,6 +26,14 @@ namespace Chinook.DynamicMvvm.Tests.Helpers
 		public event EventHandler Loaded;
 		public event EventHandler Unloaded;
 
-		public void ExecuteOnDispatcher(Action action) => _onExecuteOnDispatcher?.Invoke(action);
+		public Task ExecuteOnDispatcher(Action action)
+		{
+			_onExecuteOnDispatcher?.Invoke(action);
+			return Task.CompletedTask;
+		}
+
+		public void Dispose()
+		{
+		}
 	}
 }

--- a/src/DynamicMvvm.Tests/Integration/IntegrationTests.cs
+++ b/src/DynamicMvvm.Tests/Integration/IntegrationTests.cs
@@ -96,7 +96,7 @@ namespace Chinook.DynamicMvvm.Tests.Integration
 		}
 
 		[Fact]
-		public async Task A_disposed_VM_cannot_be_mutated()
+		public void A_disposed_VM_cannot_be_mutated()
 		{
 			var viewModel = new MyViewModel(_serviceProvider);
 
@@ -111,10 +111,19 @@ namespace Chinook.DynamicMvvm.Tests.Integration
 			Assert.Throws<ObjectDisposedException>(() => viewModel.ClearErrors(nameof(MyViewModel.Counter)));
 			Assert.Throws<ObjectDisposedException>(() => viewModel.View = new TestViewModelView());
 			Assert.Throws<ObjectDisposedException>(() => viewModel.RaisePropertyChanged(nameof(MyViewModel.Counter)));
+		}
 
-			// Extensions via exposed properties
-			Assert.Throws<ObjectDisposedException>(() => viewModel.Counter = 1);
-			await Assert.ThrowsAsync<ObjectDisposedException>(async () => await viewModel.IncrementCounter.Execute());
+		[Fact]
+		public void A_disposed_VM_returns_default_property_values()
+		{
+			var viewModel = new MyViewModel(_serviceProvider);
+			viewModel.Counter = 1;
+
+			viewModel.Dispose();
+
+			viewModel.Counter.Should().Be(default(int));
+			viewModel.Child.Should().Be(null);
+			viewModel.IncrementCounter.Should().Be(null);
 		}
 
 		[Fact]

--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseDisposableTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseDisposableTests.cs
@@ -14,6 +14,16 @@ namespace Chinook.DynamicMvvm.Tests.ViewModel
 		private const string DefaultDisposableKey = nameof(DefaultDisposableKey);
 
 		[Fact]
+		public void It_Reports_IsDisposed_Correctly()
+		{
+			var viewModel = new ViewModelBase();
+
+			viewModel.IsDisposed.Should().BeFalse();
+			viewModel.Dispose();
+			viewModel.IsDisposed.Should().BeTrue();
+		}
+
+		[Fact]
 		public void It_Adds_Anonymous_Disposable()
 		{
 			var viewModel = new ViewModelBase();

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -12,6 +12,8 @@ namespace Chinook.DynamicMvvm
 		private bool _isDisposing;
 		private bool _isDisposed;
 
+		public bool IsDisposed => _isDisposed;
+
 		/// <inheritdoc />
 		public IEnumerable<KeyValuePair<string, IDisposable>> Disposables => _disposables;
 
@@ -53,8 +55,6 @@ namespace Chinook.DynamicMvvm
 		{
 			key = key ?? throw new ArgumentNullException(nameof(key));
 
-			ThrowIfDisposed();
-
 			return _disposables.TryGetValue(key, out disposable);
 		}
 
@@ -76,7 +76,13 @@ namespace Chinook.DynamicMvvm
 
 			if (isDisposing)
 			{
+				_logger.LogDebug($"Disposing ViewModel '{Name}'.");
+
 				_isDisposing = true;
+				if (_view.TryGetTarget(out var view))
+				{
+					view.Dispose();
+				}
 				foreach (var pair in _disposables)
 				{
 					try
@@ -101,7 +107,7 @@ namespace Chinook.DynamicMvvm
 				_diagnostics.Write("Disposed", Name);
 			}
 
-			_logger.LogInformation($"ViewModel '{Name}' disposed.");
+			_logger.LogInformation($"Disposed ViewModel '{Name}'.");
 		}
 
 		/// <inheritdoc />

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Chinook.DynamicMvvm
 {
@@ -42,6 +43,12 @@ namespace Chinook.DynamicMvvm
 		{
 			ThrowIfDisposed();
 
+			if (_isDisposing)
+			{
+				_logger.LogDebug($"Skipped '{nameof(SetErrors)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				return;
+			}
+
 			_errors[propertyName] = errors;
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
@@ -52,6 +59,12 @@ namespace Chinook.DynamicMvvm
 		{
 			ThrowIfDisposed();
 
+			if (_isDisposing)
+			{
+				_logger.LogDebug($"Skipped '{nameof(SetErrors)}' for ViewModel '{Name}' because it's disposing.");
+				return;
+			}
+
 			_errors = new ConcurrentDictionary<string, IEnumerable<object>>(errors);
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName: null));
@@ -61,6 +74,12 @@ namespace Chinook.DynamicMvvm
 		public void ClearErrors(string propertyName = null)
 		{
 			ThrowIfDisposed();
+
+			if (_isDisposing)
+			{
+				_logger.LogDebug($"Skipped '{nameof(ClearErrors)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				return;
+			}
 
 			if (string.IsNullOrEmpty(propertyName))
 			{

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.View.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.View.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Chinook.DynamicMvvm
 {
@@ -34,6 +35,12 @@ namespace Chinook.DynamicMvvm
 			}
 
 			_view.SetTarget(view);
+
+			if (_isDisposing)
+			{
+				_logger.LogDebug($"Skipped invocation of '{nameof(ViewChanged)}' on ViewModel '{Name}' because it's disposing.");
+				return;
+			}
 
 			ViewChanged?.Invoke(view);
 		}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Trying to read a disposed `IViewModel`'s property written using `this.Get` throws an `ObjectDisposedException`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Reading a property from a disposed `IViewModel` yields a default value instead of throwing an `ObjectDisposedException`.
A default value is also returned when using the `GetCommandFromXXX` and `GetChild` extensions.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

