### PR TITLE
fix: properly check if there are errors with ViewModelBase.HasErrors

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
@@ -17,7 +17,7 @@ namespace Chinook.DynamicMvvm
 		public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
 
 		/// <inheritdoc />
-		public bool HasErrors => _errors.Any();
+		public bool HasErrors => _errors.Values.SelectMany(x => x).Any();
 
 		/// <inheritdoc />
 		public IEnumerable GetErrors(string propertyName)


### PR DESCRIPTION
GitHub Issue: #27

## Proposed Changes

Bug fix

## What is the current behavior?

`ViewModelBase.HasErrors` checks if the dictionary has anything in it.

## What is the new behavior?

`ViewModelBase.HasErrors` checks if the dictionary contains errors for any property name.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [x] Associated with an issue