### PR TITLE
fix: Fix ViewModelView being disposed when it shouldn't

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.5.0
+next-version: 0.6.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModelView.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModelView.cs
@@ -9,7 +9,7 @@ namespace Chinook.DynamicMvvm
 	/// <summary>
 	/// A <see cref="IViewModelView"/> represents the view contract of a <see cref="IViewModel"/>.
 	/// </summary>
-	public interface IViewModelView : IDisposable
+	public interface IViewModelView
 	{
 		/// <summary>
 		/// Gets whether or not the thread has dispatcher access.
@@ -29,7 +29,8 @@ namespace Chinook.DynamicMvvm
 		/// <summary>
 		/// Executes the specified action on a dispatcher thread.
 		/// </summary>
+		/// <param name="ct">The cancellation token.</param>
 		/// <param name="action">The action to execute.</param>
-		Task ExecuteOnDispatcher(Action action);
+		Task ExecuteOnDispatcher(CancellationToken ct, Action action);
 	}
 }

--- a/src/DynamicMvvm.Tests/Helpers/TestViewModelView.cs
+++ b/src/DynamicMvvm.Tests/Helpers/TestViewModelView.cs
@@ -26,7 +26,7 @@ namespace Chinook.DynamicMvvm.Tests.Helpers
 		public event EventHandler Loaded;
 		public event EventHandler Unloaded;
 
-		public Task ExecuteOnDispatcher(Action action)
+		public Task ExecuteOnDispatcher(CancellationToken ct, Action action)
 		{
 			_onExecuteOnDispatcher?.Invoke(action);
 			return Task.CompletedTask;

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Chinook.DynamicMvvm
@@ -9,10 +10,19 @@ namespace Chinook.DynamicMvvm
 	public partial class ViewModelBase
 	{
 		private readonly Dictionary<string, IDisposable> _disposables = new Dictionary<string, IDisposable>();
+		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
 		private bool _isDisposing;
 		private bool _isDisposed;
 
+		/// <inheritdoc/>
 		public bool IsDisposed => _isDisposed;
+
+		/// <summary>
+		/// Gets a <see cref="System.Threading.CancellationToken"/> bound to the lifetime of this <see cref="ViewModelBase"/>.
+		/// It cancels when this <see cref="ViewModelBase"/> is disposes.
+		/// </summary>
+		public CancellationToken CancellationToken => _cts.Token;
 
 		/// <inheritdoc />
 		public IEnumerable<KeyValuePair<string, IDisposable>> Disposables => _disposables;
@@ -79,10 +89,7 @@ namespace Chinook.DynamicMvvm
 				_logger.LogDebug($"Disposing ViewModel '{Name}'.");
 
 				_isDisposing = true;
-				if (_view.TryGetTarget(out var view))
-				{
-					view.Dispose();
-				}
+				_cts.Dispose();
 				foreach (var pair in _disposables)
 				{
 					try

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -30,7 +30,7 @@ namespace Chinook.DynamicMvvm
 
 			if (viewModelView != null && !viewModelView.GetHasDispatcherAccess())
 			{
-				_ = viewModelView.ExecuteOnDispatcher(() => RaisePropertyChangedInner(propertyName));
+				_ = viewModelView.ExecuteOnDispatcher(CancellationToken, () => RaisePropertyChangedInner(propertyName));
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

If a child ViewModel is disposed, it's parent's `IViewModelView` is disposed as well, breaking the dispatcher reference.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- `IViewModel` no longer implements `IDisposable`.
- `ViewModelBase` now exposes a public `CancellationToken`.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

