### PR TITLE
feat: Add IViewModel reference in factory methods to enable advanced …

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.6.0
+next-version: 0.7.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DynamicMvvm.Abstractions/Command/IDynamicCommandBuilder.cs
+++ b/src/DynamicMvvm.Abstractions/Command/IDynamicCommandBuilder.cs
@@ -16,6 +16,14 @@ namespace Chinook.DynamicMvvm
 		string Name { get; }
 
 		/// <summary>
+		/// The <see cref="IViewModel"/> that will own the resulting <see cref="IDynamicCommand"/>.
+		/// </summary>
+		/// <remarks>
+		/// This can be null.
+		/// </remarks>
+		IViewModel ViewModel { get; }
+
+		/// <summary>
 		/// Gets the base stragegy that actually invokes the user execution.
 		/// This cannot be changed.
 		/// </summary>

--- a/src/DynamicMvvm.Abstractions/Command/IDynamicCommandBuilderFactory.cs
+++ b/src/DynamicMvvm.Abstractions/Command/IDynamicCommandBuilderFactory.cs
@@ -17,10 +17,12 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">The command name.</param>
 		/// <param name="execute">The action to execute.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicCommand"/>.</param>
 		/// <returns>The created <see cref="IDynamicCommandBuilder"/>.</returns>
 		IDynamicCommandBuilder CreateFromAction(
 			string name,
-			Action execute
+			Action execute,
+			IViewModel viewModel = null
 		);
 
 		/// <summary>
@@ -30,10 +32,12 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">The command name.</param>
 		/// <param name="execute">The action to execute.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicCommand"/>.</param>
 		/// <returns>The created <see cref="IDynamicCommandBuilder"/>.</returns>
 		IDynamicCommandBuilder CreateFromAction<TParameter>(
 			string name,
-			Action<TParameter> execute
+			Action<TParameter> execute,
+			IViewModel viewModel = null
 		);
 
 		/// <summary>
@@ -42,10 +46,12 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">The command name.</param>
 		/// <param name="execute">The task to execute.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicCommand"/>.</param>
 		/// <returns>The created <see cref="IDynamicCommandBuilder"/>.</returns>
 		IDynamicCommandBuilder CreateFromTask(
 			string name,
-			Func<CancellationToken, Task> execute
+			Func<CancellationToken, Task> execute,
+			IViewModel viewModel = null
 		);
 
 		/// <summary>
@@ -55,10 +61,12 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">The command name.</param>
 		/// <param name="execute">The task to execute.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicCommand"/>.</param>
 		/// <returns>The created <see cref="IDynamicCommandBuilder"/>.</returns>
 		IDynamicCommandBuilder CreateFromTask<TParameter>(
 			string name,
-			Func<CancellationToken, TParameter, Task> execute
+			Func<CancellationToken, TParameter, Task> execute,
+			IViewModel viewModel = null
 		);
 	}
 }

--- a/src/DynamicMvvm.Abstractions/Property/IDynamicPropertyFactory.cs
+++ b/src/DynamicMvvm.Abstractions/Property/IDynamicPropertyFactory.cs
@@ -17,10 +17,12 @@ namespace Chinook.DynamicMvvm
 		/// <typeparam name="T">The property type.</typeparam>
 		/// <param name="name">The property name.</param>
 		/// <param name="initialValue">The initial value.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicProperty"/>.</param>
 		/// <returns><see cref="IDynamicProperty"/></returns>
 		IDynamicProperty Create<T>(
 			string name,
-			T initialValue = default
+			T initialValue = default,
+			IViewModel viewModel = null
 		);
 
 		/// <summary>
@@ -31,11 +33,13 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">The property name.</param>
 		/// <param name="source">The property source.</param>
 		/// <param name="initialValue">The initial value.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicProperty"/>.</param>
 		/// <returns><see cref="IDynamicProperty"/></returns>
 		IDynamicProperty CreateFromTask<T>(
 			string name,
 			Func<CancellationToken, Task<T>> source,
-			T initialValue = default
+			T initialValue = default,
+			IViewModel viewModel = null
 		);
 
 		/// <summary>
@@ -46,11 +50,13 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">The property name.</param>
 		/// <param name="source">The property source.</param>
 		/// <param name="initialValue">The initial value.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicProperty"/>.</param>
 		/// <returns><see cref="IDynamicProperty"/></returns>
 		IDynamicProperty CreateFromObservable<T>(
 			string name,
 			IObservable<T> source,
-			T initialValue = default
+			T initialValue = default,
+			IViewModel viewModel = null
 		);
 	}
 }

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Commands.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Commands.cs
@@ -27,7 +27,7 @@ namespace Chinook.DynamicMvvm
 			Action execute,
 			Func<IDynamicCommandBuilder, IDynamicCommandBuilder> configure = null,
 			[CallerMemberName] string name = null
-		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromAction(n, execute), configure);
+		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromAction(n, execute, viewModel), configure);
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicCommand"/> that will execute
@@ -44,7 +44,7 @@ namespace Chinook.DynamicMvvm
 			Action<TParameter> execute,
 			Func<IDynamicCommandBuilder, IDynamicCommandBuilder> configure = null,
 			[CallerMemberName] string name = null
-		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromAction(n, execute), configure);
+		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromAction(n, execute, viewModel), configure);
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicCommand"/> that will execute
@@ -60,7 +60,7 @@ namespace Chinook.DynamicMvvm
 			Func<CancellationToken, Task> execute,
 			Func<IDynamicCommandBuilder, IDynamicCommandBuilder> configure = null,
 			[CallerMemberName] string name = null
-		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromTask(n, execute), configure);
+		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromTask(n, execute, viewModel), configure);
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicCommand"/> that will execute
@@ -77,7 +77,7 @@ namespace Chinook.DynamicMvvm
 			Func<CancellationToken, TParameter, Task> execute,
 			Func<IDynamicCommandBuilder, IDynamicCommandBuilder> configure = null,
 			[CallerMemberName] string name = null
-		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromTask(n, execute), configure);
+		) => viewModel.GetOrCreateCommand(name, n => viewModel.GetDynamicCommandBuilderFactory().CreateFromTask(n, execute, viewModel), configure);
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicCommand"/> that will be attached to the <paramref name="viewModel"/>.

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
@@ -46,7 +46,7 @@ namespace Chinook.DynamicMvvm
 			this IViewModel viewModel,
 			T initialValue = default,
 			[CallerMemberName] string name = null
-		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().Create(n, initialValue)));
+		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().Create(n, initialValue, viewModel)));
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.
@@ -60,7 +60,7 @@ namespace Chinook.DynamicMvvm
 			this IViewModel viewModel,
 			Func<T> initialValue,
 			[CallerMemberName] string name = null
-		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().Create(n, initialValue())));
+		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().Create(n, initialValue(), viewModel)));
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.
@@ -76,7 +76,7 @@ namespace Chinook.DynamicMvvm
 			Func<CancellationToken, Task<T>> source,
 			T initialValue = default,
 			[CallerMemberName] string name = null
-		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().CreateFromTask(n, source, initialValue)));
+		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().CreateFromTask(n, source, initialValue, viewModel)));
 
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.
@@ -92,7 +92,7 @@ namespace Chinook.DynamicMvvm
 			IObservable<T> source,
 			T initialValue = default,
 			[CallerMemberName] string name = null
-		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().CreateFromObservable(n, source, initialValue)));
+		) => viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => viewModel.GetDynamicPropertyFactory().CreateFromObservable(n, source, initialValue, viewModel)));
 
 		/// <summary>
 		/// Sets the value of a property.

--- a/src/DynamicMvvm.Tests/Command/DynamicCommandBuilderExtensionsTests.cs
+++ b/src/DynamicMvvm.Tests/Command/DynamicCommandBuilderExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Chinook.DynamicMvvm.Tests.Command
 		[Fact]
 		public void WithStrategy_properly_adds()
 		{
-			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }));
+			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }), null);
 
 			builder.Strategies.Should().BeEmpty();
 
@@ -25,7 +25,7 @@ namespace Chinook.DynamicMvvm.Tests.Command
 		[Fact]
 		public void WithoutStrategy_properly_removes()
 		{
-			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }))
+			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }), null)
 				.OnBackgroundThread()
 				.Locked()
 				.DisableWhileExecuting();
@@ -40,7 +40,7 @@ namespace Chinook.DynamicMvvm.Tests.Command
 		[Fact]
 		public void ClearStrategies_properly_clears()
 		{
-			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }))
+			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }), null)
 				.OnBackgroundThread()
 				.Locked()
 				.DisableWhileExecuting();
@@ -51,6 +51,6 @@ namespace Chinook.DynamicMvvm.Tests.Command
 			builder.ClearStrategies();
 
 			builder.Strategies.Should().BeEmpty();
-		}
+		}		
 	}
 }

--- a/src/DynamicMvvm.Tests/Command/DynamicCommandBuilderFactoryTests.cs
+++ b/src/DynamicMvvm.Tests/Command/DynamicCommandBuilderFactoryTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Chinook.DynamicMvvm.Tests.Helpers;
 using FluentAssertions;
 using Xunit;
 
@@ -153,6 +154,26 @@ namespace Chinook.DynamicMvvm.Tests.Command
 			await command.Execute();
 
 			testString.Should().Be("123");
+		}
+
+		[Fact]
+		public void It_passes_ViewModel_owner_correctly()
+		{
+			var owner = new TestViewModel();
+
+			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }), owner); ;
+
+			builder.ViewModel.Should().Be(owner);
+		}
+
+		[Fact]
+		public void It_passes_ViewModel_owner_correctly_when_null()
+		{
+			var owner = default(IViewModel);
+
+			var builder = new DynamicCommandBuilder("myCommand", new ActionCommandStrategy(() => { }), owner); ;
+
+			builder.ViewModel.Should().BeNull();
 		}
 
 		private class TestParameter { }

--- a/src/DynamicMvvm/Command/DynamicCommandBuilder.cs
+++ b/src/DynamicMvvm/Command/DynamicCommandBuilder.cs
@@ -17,7 +17,8 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">The name of the command.</param>
 		/// <param name="baseStrategy">The base strategy to use for the command.</param>
-		public DynamicCommandBuilder(string name, IDynamicCommandStrategy baseStrategy)
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created <see cref="IDynamicCommand"/>.</param>
+		public DynamicCommandBuilder(string name, IDynamicCommandStrategy baseStrategy, IViewModel viewModel = null)
 		{
 			if (string.IsNullOrEmpty(name))
 			{
@@ -25,11 +26,15 @@ namespace Chinook.DynamicMvvm
 			}
 
 			Name = name;
+			ViewModel = viewModel;
 			BaseStrategy = baseStrategy ?? throw new ArgumentNullException(nameof(baseStrategy));
 		}
 
 		/// <inheritdoc/>
 		public string Name { get; }
+
+		/// <inheritdoc/>
+		public IViewModel ViewModel { get; }
 
 		/// <inheritdoc/>
 		public IDynamicCommandStrategy BaseStrategy { get; }

--- a/src/DynamicMvvm/Command/DynamicCommandBuilderFactory.cs
+++ b/src/DynamicMvvm/Command/DynamicCommandBuilderFactory.cs
@@ -28,9 +28,9 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">Command name</param>
 		/// <param name="strategy"><see cref="IDynamicCommandStrategy"/></param>
 		/// <returns><see cref="IDynamicCommandBuilder"/></returns>
-		protected IDynamicCommandBuilder CreateBuilder(string name, IDynamicCommandStrategy strategy)
+		protected IDynamicCommandBuilder CreateBuilder(string name, IDynamicCommandStrategy strategy, IViewModel viewModel)
 		{
-			IDynamicCommandBuilder builder = new DynamicCommandBuilder(name, strategy);
+			IDynamicCommandBuilder builder = new DynamicCommandBuilder(name, strategy, viewModel);
 
 			if (_defaultConfigure != null)
 			{
@@ -41,19 +41,19 @@ namespace Chinook.DynamicMvvm
 		}
 
 		/// <inheritdoc />
-		public virtual IDynamicCommandBuilder CreateFromAction(string name, Action execute)
-			=> CreateBuilder(name, new ActionCommandStrategy(execute));
+		public virtual IDynamicCommandBuilder CreateFromAction(string name, Action execute, IViewModel viewModel = null)
+			=> CreateBuilder(name, new ActionCommandStrategy(execute), viewModel);
 
 		/// <inheritdoc />
-		public virtual IDynamicCommandBuilder CreateFromAction<TParameter>(string name, Action<TParameter> execute)
-			=> CreateBuilder(name, new ActionCommandStrategy<TParameter>(execute));
+		public virtual IDynamicCommandBuilder CreateFromAction<TParameter>(string name, Action<TParameter> execute, IViewModel viewModel = null)
+			=> CreateBuilder(name, new ActionCommandStrategy<TParameter>(execute), viewModel);
 
 		/// <inheritdoc />
-		public virtual IDynamicCommandBuilder CreateFromTask(string name, Func<CancellationToken, Task> execute)
-			=> CreateBuilder(name, new TaskCommandStrategy(execute));
+		public virtual IDynamicCommandBuilder CreateFromTask(string name, Func<CancellationToken, Task> execute, IViewModel viewModel = null)
+			=> CreateBuilder(name, new TaskCommandStrategy(execute), viewModel);
 
 		/// <inheritdoc />
-		public virtual IDynamicCommandBuilder CreateFromTask<TParameter>(string name, Func<CancellationToken, TParameter, Task> execute)
-			=> CreateBuilder(name, new TaskCommandStrategy<TParameter>(execute));
+		public virtual IDynamicCommandBuilder CreateFromTask<TParameter>(string name, Func<CancellationToken, TParameter, Task> execute, IViewModel viewModel = null)
+			=> CreateBuilder(name, new TaskCommandStrategy<TParameter>(execute), viewModel);
 	}
 }

--- a/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
@@ -9,19 +9,22 @@ namespace Chinook.DynamicMvvm
 	/// <summary>
 	/// This is a default implementation of <see cref="IDynamicPropertyFactory"/>.
 	/// </summary>
+	/// <remarks>
+	/// This implementation doesn't actually require the viewModel parameter.
+	/// </remarks>
 	[Preserve(AllMembers = true)]
 	public class DynamicPropertyFactory : IDynamicPropertyFactory
 	{
 		/// <inheritdoc />
-		public virtual IDynamicProperty Create<T>(string name, T initialValue = default)
+		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
 			=> new DynamicProperty<T>(name, initialValue);
 
 		/// <inheritdoc />
-		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default)
+		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
 			=> new DynamicPropertyFromTask<T>(name, source, initialValue);
 
 		/// <inheritdoc />
-		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default)
+		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
 			=> new DynamicPropertyFromObservable<T>(name, source, initialValue);
 	}
 }

--- a/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
@@ -53,9 +53,9 @@ namespace Chinook.DynamicMvvm
 
 		public class DynamicPropertyObserver : IObserver<T>
 		{
-			private readonly DynamicPropertyFromObservable<T> _owner;
+			private readonly IDynamicProperty<T> _owner;
 
-			public DynamicPropertyObserver(DynamicPropertyFromObservable<T> owner)
+			public DynamicPropertyObserver(IDynamicProperty<T> owner)
 			{
 				_owner = owner;
 			}


### PR DESCRIPTION
…implementations.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Advanced implementations of IDynamicProperty or IDynamicCommandStrategy can be difficult to make because there's no reference to the owning viewmodel.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

`IDynamicPropertyFactory` and `IDynamicCommandBuilderFactory` now propagate an `IViewModel` owner when provided.


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
   **It contains breaking changes, but the version was bumped.**
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

