### PR TITLE
feat: Add an overload of Get for typed dynamic properties.

### DIFF
--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
@@ -35,6 +35,25 @@ namespace Chinook.DynamicMvvm
 		}
 
 		/// <summary>
+		/// Gets the value of a <see cref="IDynamicProperty{T}"/>.
+		/// </summary>
+		/// <typeparam name="T">The property type.</typeparam>
+		/// <param name="viewModel">The <see cref="IViewModel"/> owning the property.</param>
+		/// <param name="property">The property.</param>
+		/// <returns>The property's value. Default of <typeparamref name="T"/> is returned if the <see cref="IViewModel"/> is disposed or if <paramref name="property"/> is null.</returns>
+		public static T Get<T>(
+			this IViewModel viewModel,
+			IDynamicProperty<T> property)
+		{
+			if (viewModel.IsDisposed || property == null)
+			{
+				return default(T);
+			}
+
+			return property.Value;
+		}
+
+		/// <summary>
 		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.
 		/// </summary>
 		/// <typeparam name="T">The property type.</typeparam>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

`IViewModelExtensions.Get<T>(this IViewModel viewModel, IDynamicProperty property)` can throw an invalid cast exception when the property class implements `IDynamicProperty<T>` for multiple types.
e.g. A class that implements both `IDynamicProperty<decimal>` and `IDynamicProperty<int>`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The previously mention exception can now be avoided by using the newly added overload.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

