### PR TITLE
feat: Support adding child viewmodels as dynamic properties

### DIFF
--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
@@ -217,7 +217,12 @@ namespace Chinook.DynamicMvvm
 				property = factory(name);
 				property.ValueChanged += OnDynamicPropertyChanged;
 
-				viewModel.AddDisposable(name, property);
+				// We check the same condition twice because it's possible that the factory invocation already added the property.
+				// This can happen when the property implements IViewModel and was added using AttachChild.
+				if (!viewModel.TryGetDisposable<IDynamicProperty>(name, out var _))
+				{
+					viewModel.AddDisposable(name, property);
+				}
 			}
 
 			return property;


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Using `AttachChild` from within the `GetOrCreateDynamicProperty` factory can lead to an argument exception.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

It is now possible to use `AttachChild` from within the `GetOrCreateDynamicProperty` factory to add properties that implement `IViewModel` as well as `IDynamicProperty` without errors.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

