### PR TITLE
fix: Remove canExecute funcs from ActionCommandStrategy and TaskCommandStrategy

### DIFF
--- a/src/DynamicMvvm.Tests/Command/Strategies/ActionCommandStrategyTests.cs
+++ b/src/DynamicMvvm.Tests/Command/Strategies/ActionCommandStrategyTests.cs
@@ -29,12 +29,10 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 		[Fact]
 		public async Task It_Executes_With_Parameter()
 		{
-			var canExecuteStrategyParameter = default(object);
 			var executeStrategyParameter = default(object);
 
 			var strategy = new ActionCommandStrategy(
-				execute: p => executeStrategyParameter = p,
-				canExecute: p => { canExecuteStrategyParameter = p; return true; }
+				execute: p => executeStrategyParameter = p
 			);
 
 			var command = new DynamicCommand(DefaultCommandName, strategy);
@@ -42,19 +40,16 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 			var parameter = new object();
 			await command.Execute(parameter);
 
-			canExecuteStrategyParameter.Should().Be(parameter);
 			executeStrategyParameter.Should().Be(parameter);
 		}
 
 		[Fact]
 		public async Task It_Executes_With_Parameter_T()
 		{
-			var canExecuteStrategyParameter = default(TestParameter);
 			var executeStrategyParameter = default(TestParameter);
 
 			var strategy = new ActionCommandStrategy<TestParameter>(
-				execute: p => executeStrategyParameter = p,
-				canExecute: p => { canExecuteStrategyParameter = p; return true; }
+				execute: p => executeStrategyParameter = p
 			);
 
 			var command = new DynamicCommand(DefaultCommandName, strategy);
@@ -62,44 +57,9 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 			var parameter = new TestParameter();
 			await command.Execute(parameter);
 
-			canExecuteStrategyParameter.Should().Be(parameter);
 			executeStrategyParameter.Should().Be(parameter);
 		}
-
-		[Fact]
-		public async Task It_Doesnt_Execute_When_CantExecute()
-		{
-			var isExecuted = false;
-
-			var strategy = new ActionCommandStrategy(
-				execute: () => isExecuted = true,
-				canExecute: _ => false
-			);
-
-			var command = new DynamicCommand(DefaultCommandName, strategy);
-
-			await command.Execute();
-
-			isExecuted.Should().BeFalse();
-		}
-
-		[Fact]
-		public async Task It_Doesnt_Execute_When_CantExecute_T()
-		{
-			var isExecuted = false;
-
-			var strategy = new ActionCommandStrategy<TestParameter>(
-				execute: p => isExecuted = true,
-				canExecute: _ => false
-			);
-
-			var command = new DynamicCommand(DefaultCommandName, strategy);
-
-			await command.Execute();
-
-			isExecuted.Should().BeFalse();
-		}
-
+				
 		private class TestParameter {	}
 	}
 }

--- a/src/DynamicMvvm.Tests/Command/Strategies/TaskCommandStrategyTests.cs
+++ b/src/DynamicMvvm.Tests/Command/Strategies/TaskCommandStrategyTests.cs
@@ -36,7 +36,6 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 		[Fact]
 		public async Task It_Executes_With_Parameter()
 		{
-			var canExecuteStrategyParameter = default(object);
 			var executeStrategyParameter = default(object);
 
 			var strategy = new TaskCommandStrategy(
@@ -45,8 +44,7 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 					executeStrategyParameter = p;
 
 					return Task.CompletedTask;
-				},
-				canExecute: p => { canExecuteStrategyParameter = p; return true; }
+				}
 			);
 
 			var command = new DynamicCommand(DefaultCommandName, strategy);
@@ -54,14 +52,12 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 			var parameter = new object();
 			await command.Execute(parameter);
 
-			canExecuteStrategyParameter.Should().Be(parameter);
 			executeStrategyParameter.Should().Be(parameter);
 		}
 
 		[Fact]
 		public async Task It_Executes_With_Parameter_T()
 		{
-			var canExecuteStrategyParameter = default(TestParameter);
 			var executeStrategyParameter = default(TestParameter);
 
 			var strategy = new TaskCommandStrategy<TestParameter>(
@@ -70,8 +66,7 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 					executeStrategyParameter = p;
 
 					return Task.CompletedTask;
-				},
-				canExecute: p => { canExecuteStrategyParameter = p; return true; }
+				}
 			);
 
 			var command = new DynamicCommand(DefaultCommandName, strategy);
@@ -79,52 +74,7 @@ namespace Chinook.DynamicMvvm.Tests.Command.Strategies
 			var parameter = new TestParameter();
 			await command.Execute(parameter);
 
-			canExecuteStrategyParameter.Should().Be(parameter);
 			executeStrategyParameter.Should().Be(parameter);
-		}
-
-		[Fact]
-		public async Task It_Doesnt_Execute_When_CantExecute()
-		{
-			var isExecuted = false;
-
-			var strategy = new TaskCommandStrategy(
-				execute: ct =>
-				{
-					isExecuted = true;
-
-					return Task.CompletedTask;
-				},
-				canExecute: _ => false
-			);
-
-			var command = new DynamicCommand(DefaultCommandName, strategy);
-
-			await command.Execute();
-
-			isExecuted.Should().BeFalse();
-		}
-
-		[Fact]
-		public async Task It_Doesnt_Execute_When_CantExecute_T()
-		{
-			var isExecuted = false;
-
-			var strategy = new TaskCommandStrategy<TestParameter>(
-				execute: (ct, p) =>
-				{
-					isExecuted = true;
-
-					return Task.CompletedTask;
-				},
-				canExecute: _ => false
-			);
-
-			var command = new DynamicCommand(DefaultCommandName, strategy);
-
-			await command.Execute();
-
-			isExecuted.Should().BeFalse();
 		}
 
 		private class TestParameter { }

--- a/src/DynamicMvvm/Command/Strategies/ActionCommandStrategy.T.cs
+++ b/src/DynamicMvvm/Command/Strategies/ActionCommandStrategy.T.cs
@@ -12,34 +12,17 @@ namespace Chinook.DynamicMvvm
 	/// </summary>
 	public class ActionCommandStrategy<TParameter> : ActionCommandStrategy
 	{
-		private static readonly Func<TParameter, bool> _defaultCanExecute = _ => true;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ActionCommandStrategy{TParameter}"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public ActionCommandStrategy(Action<TParameter> execute, Func<TParameter, bool> canExecute)
-			: base(p => execute((TParameter)p), p => canExecute((TParameter)p))
-		{
-			if (execute == null)
-			{
-				throw new ArgumentNullException(nameof(execute));
-			}
-
-			if (canExecute == null)
-			{
-				throw new ArgumentNullException(nameof(canExecute));
-			}
-		}
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ActionCommandStrategy{TParameter}"/> class.
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
 		public ActionCommandStrategy(Action<TParameter> execute)
-			: this(execute, _defaultCanExecute)
+			: base(p => execute((TParameter)p))
 		{
+			if (execute == null)
+			{
+				throw new ArgumentNullException(nameof(execute));
+			}
 		}
 	}
 }

--- a/src/DynamicMvvm/Command/Strategies/ActionCommandStrategy.cs
+++ b/src/DynamicMvvm/Command/Strategies/ActionCommandStrategy.cs
@@ -11,48 +11,15 @@ namespace Chinook.DynamicMvvm
 	/// </summary>
 	public class ActionCommandStrategy : IDynamicCommandStrategy
 	{
-		private static readonly Func<object, bool> _defaultCanExecute = _ => true;
-
-		private readonly Func<object, bool> _canExecute;
 		private readonly Action<object> _execute;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ActionCommandStrategy"/> class.
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public ActionCommandStrategy(Action<object> execute, Func<object, bool> canExecute)
+		public ActionCommandStrategy(Action<object> execute)
 		{
 			_execute = execute ?? throw new ArgumentNullException(nameof(execute));
-			_canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ActionCommandStrategy"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public ActionCommandStrategy(Action execute, Func<object, bool> canExecute)
-			: this(_ => execute(), canExecute)
-		{
-			if (execute == null)
-			{
-				throw new ArgumentNullException(nameof(execute));
-			}
-
-			if (canExecute == null)
-			{
-				throw new ArgumentNullException(nameof(canExecute));
-			}
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ActionCommandStrategy"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		public ActionCommandStrategy(Action<object> execute)
-			: this(execute, _defaultCanExecute)
-		{
 		}
 
 		/// <summary>
@@ -60,16 +27,19 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
 		public ActionCommandStrategy(Action execute)
-			: this(execute, _defaultCanExecute)
+			: this(_ => execute())
 		{
+			if (execute == null)
+			{
+				throw new ArgumentNullException(nameof(execute));
+			}
 		}
 
 		/// <inheritdoc />
 		public event EventHandler CanExecuteChanged;
 
 		/// <inheritdoc />
-		public bool CanExecute(object parameter, IDynamicCommand command)
-			=> _canExecute(parameter);
+		public bool CanExecute(object parameter, IDynamicCommand command) => true;
 
 		/// <inheritdoc />
 		public Task Execute(CancellationToken ct, object parameter, IDynamicCommand command)

--- a/src/DynamicMvvm/Command/Strategies/TaskCommandStrategy.T.cs
+++ b/src/DynamicMvvm/Command/Strategies/TaskCommandStrategy.T.cs
@@ -12,34 +12,17 @@ namespace Chinook.DynamicMvvm
 	/// </summary>
 	public class TaskCommandStrategy<TParameter> : TaskCommandStrategy
 	{
-		private static readonly Func<TParameter, bool> _defaultCanExecute = _ => true;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TaskCommandStrategy{TParameter}"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public TaskCommandStrategy(Func<CancellationToken, TParameter, Task> execute, Func<TParameter, bool> canExecute)
-			: base((ct, p) => execute(ct, (TParameter)p), p => canExecute((TParameter)p))
-		{
-			if (execute == null)
-			{
-				throw new ArgumentNullException(nameof(execute));
-			}
-
-			if (canExecute == null)
-			{
-				throw new ArgumentNullException(nameof(canExecute));
-			}
-		}
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TaskCommandStrategy{TParameter}"/> class.
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
 		public TaskCommandStrategy(Func<CancellationToken, TParameter, Task> execute)
-			: this(execute, _defaultCanExecute)
+			: base((ct, p) => execute(ct, (TParameter)p))
 		{
+			if (execute == null)
+			{
+				throw new ArgumentNullException(nameof(execute));
+			}
 		}
 	}
 }

--- a/src/DynamicMvvm/Command/Strategies/TaskCommandStrategy.cs
+++ b/src/DynamicMvvm/Command/Strategies/TaskCommandStrategy.cs
@@ -11,48 +11,15 @@ namespace Chinook.DynamicMvvm
 	/// </summary>
 	public class TaskCommandStrategy : IDynamicCommandStrategy
 	{
-		private static readonly Func<object, bool> _defaultCanExecute = _ => true;
-
-		private readonly Func<object, bool> _canExecute;
 		private readonly Func<CancellationToken, object, Task> _execute;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="TaskCommandStrategy"/> class.
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public TaskCommandStrategy(Func<CancellationToken, object, Task> execute, Func<object, bool> canExecute)
+		public TaskCommandStrategy(Func<CancellationToken, object, Task> execute)
 		{
 			_execute = execute ?? throw new ArgumentNullException(nameof(execute));
-			_canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TaskCommandStrategy"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		/// <param name="canExecute">Can execute evaluator</param>
-		public TaskCommandStrategy(Func<CancellationToken, Task> execute, Func<object, bool> canExecute)
-			: this((ct, _) => execute(ct), canExecute)
-		{
-			if (execute == null)
-			{
-				throw new ArgumentNullException(nameof(execute));
-			}
-
-			if (canExecute == null)
-			{
-				throw new ArgumentNullException(nameof(canExecute));
-			}
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="TaskCommandStrategy"/> class.
-		/// </summary>
-		/// <param name="execute">Action to execute</param>
-		public TaskCommandStrategy(Func<CancellationToken, object, Task> execute)
-		   : this(execute, _defaultCanExecute)
-		{
 		}
 
 		/// <summary>
@@ -60,7 +27,7 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="execute">Action to execute</param>
 		public TaskCommandStrategy(Func<CancellationToken, Task> execute)
-			: this((ct, _) => execute(ct), _defaultCanExecute)
+			: this((ct, _) => execute(ct))
 		{
 			if (execute == null)
 			{
@@ -69,8 +36,7 @@ namespace Chinook.DynamicMvvm
 		}
 
 		/// <inheritdoc />
-		public bool CanExecute(object parameter, IDynamicCommand command)
-			=> _canExecute(parameter);
+		public bool CanExecute(object parameter, IDynamicCommand command) => true;
 
 		/// <inheritdoc />
 		public Task Execute(CancellationToken ct, object parameter, IDynamicCommand command)


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- There are sometimes null reference exceptions getting thrown from the canExecute of `ActionCommandStrategy` or `TaskCommandStrategy`.
  - Note however that those `canExecute` funcs are not actually used and are not as good as `CanExecuteCommandStrategy`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- It is no longer possible to instanciate `ActionCommandStrategy` or `TaskCommandStrategy` with a `canExecute` parameter.
  - `CanExecuteCommandStrategy` is (and always has been) the proper way of specifying a `CanExecute` func.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes (no change to Abstractions package)
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

