### PR TITLE
fix: Fix IDynamicProperty.GetAndObserve extension

### DIFF
--- a/src/DynamicMvvm.Tests/Reactive/DynamicPropertyExtensionsTests.cs
+++ b/src/DynamicMvvm.Tests/Reactive/DynamicPropertyExtensionsTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.Reactive
+{
+	public class DynamicPropertyExtensionsTests
+	{
+		[Fact]
+		public async Task The_first_value_of_GetAndObserve_is_the_current_value_of_the_property()
+		{
+			var property = new DynamicProperty<int>("TestProperty", value: 0);
+			var observable = property.GetAndObserve();
+
+			var firstValue = await observable.FirstAsync();
+			firstValue.Should().Be(0);
+
+			property.Value = 1;
+
+			var secondValue = await observable.FirstAsync();
+			secondValue.Should().Be(1);
+		}
+
+		[Fact]
+		public async Task Observe_doesnt_yield_until_property_changes()
+		{
+			var property = new DynamicProperty<int>("TestProperty", value: 0);
+			var observable = property.Observe();
+
+			var task = observable.FirstAsync().ToTask();
+
+			Assert.True(task.Status == TaskStatus.Running
+				|| task.Status == TaskStatus.WaitingForActivation);
+
+			property.Value = 1;
+
+			var value = await task;
+			value.Should().Be(1);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

When using `GetAndObserve`, the value from `StartWith` can be the wrong one based on how you use the observable.
It works fine if you subscribe to the observable once.
However, if you subscribe to the same observable again, the `StartWith` will cause the observable sequence to play the value captured when the observable was created, not the current value of the property.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The new implementation of `GetAndObserve` doesn't use `StartWith`. It uses `Observable.Create` to make sure the first value of the sequence is the current value of the property, no matter the situation.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

