### PR TITLE
fix: Prevent object disposed exception when reading ViewModelBase.CancellationToken

### DIFF
--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseDisposableTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseDisposableTests.cs
@@ -136,5 +136,21 @@ namespace Chinook.DynamicMvvm.Tests.ViewModel
 
 			viewModel.Disposables.Should().BeEmpty();
 		}
+
+		[Fact]
+		public void It_Exposes_A_Not_Cancelled_Token_When_Not_Disposed()
+		{
+			var viewModel = new ViewModelBase();
+			viewModel.CancellationToken.IsCancellationRequested.Should().BeFalse();
+		}
+
+		[Fact]
+		public void It_Exposes_A_Cancelled_Token_When_Disposed()
+		{
+			var viewModel = new ViewModelBase();
+
+			viewModel.Dispose();
+			viewModel.CancellationToken.IsCancellationRequested.Should().BeTrue();
+		}
 	}
 }

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -22,7 +22,7 @@ namespace Chinook.DynamicMvvm
 		/// Gets a <see cref="System.Threading.CancellationToken"/> bound to the lifetime of this <see cref="ViewModelBase"/>.
 		/// It cancels when this <see cref="ViewModelBase"/> is disposes.
 		/// </summary>
-		public CancellationToken CancellationToken => _cts.Token;
+		public CancellationToken CancellationToken { get; }
 
 		/// <inheritdoc />
 		public IEnumerable<KeyValuePair<string, IDisposable>> Disposables => _disposables;
@@ -89,6 +89,7 @@ namespace Chinook.DynamicMvvm
 				_logger.LogDebug($"Disposing ViewModel '{Name}'.");
 
 				_isDisposing = true;
+				_cts.Cancel();
 				_cts.Dispose();
 				foreach (var pair in _disposables)
 				{

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.cs
@@ -24,6 +24,7 @@ namespace Chinook.DynamicMvvm
 		{
 			Name = name ?? GetType().Name;
 			ServiceProvider = serviceProvider ?? DefaultServiceProvider;
+			CancellationToken = _cts.Token;
 
 			_logger = typeof(ViewModelBase).Log();
 


### PR DESCRIPTION
## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

We get an ObjectDisposedException when accessing `ViewModelBase.CancellationToken` after disposing the view model.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

We get an cancelled token when accessing `ViewModelBase.CancellationToken` after disposing the view model.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

