### PR TITLE
target Android 12 and use VS2022 to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+* Support for Android 12 (March, 2022)
 * Support for Android 11 (March, 2021)
 
 ### Changed
+* Update UWP target to 19041 and net framework to 4.7.2
+* Build with VS2022
 * [#09] Update Android target to 10.0
 * [#10] Update the source of the `ViewModelBase` private `ILogger` instance.
 * [#39] Change target Uno.UI version to 4.0.7.
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 
 ### Removed
+* Support for Android 10 (March, 2022)
 
 ### Fixed
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,13 +7,13 @@
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
-  value: 5.8.1
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 16.8.6
+  value: 17.1.1
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -22,7 +22,7 @@ variables:
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.8.0
+next-version: 0.9.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DynamicMvvm.Tests/DynamicMvvm.Tests.csproj
+++ b/src/DynamicMvvm.Tests/DynamicMvvm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
 		<AssemblyName>Chinook.DynamicMvvm.Tests</AssemblyName>
     <RootNamespace>Chinook.DynamicMvvm.Tests</RootNamespace>

--- a/src/DynamicMvvm.Uno/DynamicMvvm.Uno.csproj
+++ b/src/DynamicMvvm.Uno/DynamicMvvm.Uno.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <RootNamespace>Chinook.DynamicMvvm</RootNamespace>
@@ -18,7 +18,7 @@
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='monoandroid12.0' or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Uno.UI" Version="4.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
GitHub Issue: N/A

## Proposed Changes
Remove support for Android 10
Update UWP target to 19041 and net framework to 4.7.2
Build with VS2022
Support for Android 12

Feature
Build or CI related changes
Documentation content changes 


## What is the current behavior?
No support for Android 12


## What is the new behavior?
Support for Android 12


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore

## Other information

