### PR TITLE
feat: Add new dynamic property implementations

### DIFF
--- a/src/DynamicMvvm.Tests/Property/ValueChangedOnBackgroundTaskDynamicPropertyTests.cs
+++ b/src/DynamicMvvm.Tests/Property/ValueChangedOnBackgroundTaskDynamicPropertyTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm.Implementations;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.Property
+{
+	public class ValueChangedOnBackgroundTaskDynamicPropertyTests
+	{
+		[Fact]
+		public async Task ValueChanged_is_raised_on_a_different_task_when_dispatcher_access_is_true()
+		{
+			var vm = new ViewModelBase
+			{
+				View = new TestViewModelView()
+				{
+					HasDispatcherAccess = true
+				}
+			};
+
+			var syncContext = new TaskCompletionSource<SynchronizationContext>();
+			var thread = new TaskCompletionSource<Thread>();
+			var mainContext = SynchronizationContext.Current;
+			var mainThread = Thread.CurrentThread;
+			var sut = new ValueChangedOnBackgroundTaskDynamicProperty("sut", vm);
+
+			sut.ValueChanged += OnValueChanged;
+			sut.Value = 1;
+
+			var valueChangedContext = await syncContext.Task;
+			var valueChangedThread = await thread.Task;
+
+			valueChangedContext.Should().NotBe(mainContext);
+			valueChangedThread.Should().NotBe(mainThread);
+
+			void OnValueChanged(IDynamicProperty property)
+			{
+				syncContext.SetResult(SynchronizationContext.Current);
+				thread.SetResult(Thread.CurrentThread);
+			}
+		}
+
+		[Fact]
+		public async Task ValueChanged_is_raised_on_the_same_task_when_dispatcher_access_is_false()
+		{
+			var vm = new ViewModelBase
+			{
+				View = new TestViewModelView()
+				{
+					HasDispatcherAccess = false
+				}
+			};
+
+			var syncContext = new TaskCompletionSource<SynchronizationContext>();
+			var thread = new TaskCompletionSource<Thread>();
+			var mainContext = SynchronizationContext.Current;
+			var mainThread = Thread.CurrentThread;
+			var sut = new ValueChangedOnBackgroundTaskDynamicProperty("sut", vm);
+
+			sut.ValueChanged += OnValueChanged;
+			sut.Value = 1;
+
+			var valueChangedContext = await syncContext.Task;
+			var valueChangedThread = await thread.Task;
+
+			valueChangedContext.Should().Be(mainContext);
+			valueChangedThread.Should().Be(mainThread);
+
+			void OnValueChanged(IDynamicProperty property)
+			{
+				syncContext.SetResult(SynchronizationContext.Current);
+				thread.SetResult(Thread.CurrentThread);
+			}
+		}
+
+		private class TestViewModelView : IViewModelView
+		{
+			public bool HasDispatcherAccess { get; set; }
+
+			public event EventHandler Loaded;
+			public event EventHandler Unloaded;
+
+			public Task ExecuteOnDispatcher(CancellationToken ct, Action action)
+			{
+				action();
+				return Task.CompletedTask;
+			}
+
+			public bool GetHasDispatcherAccess()
+			{
+				return HasDispatcherAccess;
+			}
+		}
+	}
+}

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicProperty.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicProperty.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm.Implementations
+{
+	/// <summary>
+	/// This implementation of <see cref="IDynamicProperty"/> ensures that <see cref="IDynamicProperty.ValueChanged"/> is raised on a background thread.
+	/// </summary>
+	public class ValueChangedOnBackgroundTaskDynamicProperty : IDynamicProperty
+	{
+		private static readonly DiagnosticSource _diagnostics = new DiagnosticListener("Chinook.DynamicMvvm.IDynamicProperty");
+		private readonly WeakReference<IViewModel> _viewModel;
+		private object _value;
+		private bool _isDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicProperty"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="value">The initial value of this property.</param>
+		public ValueChangedOnBackgroundTaskDynamicProperty(string name, IViewModel viewModel, object value = default)
+		{
+			Name = name;
+			_viewModel = new WeakReference<IViewModel>(viewModel);
+			_value = value;
+
+			if (_diagnostics.IsEnabled("Created"))
+			{
+				_diagnostics.Write("Created", Name);
+			}
+		}
+
+		protected bool IsOnDispatcher => _viewModel.TryGetTarget(out var vm) && (vm.View?.GetHasDispatcherAccess() ?? false);
+
+		/// <inheritdoc />
+		public string Name { get; }
+
+		/// <inheritdoc />
+		public virtual object Value
+		{
+			get => _value;
+			set
+			{
+				if (_isDisposed)
+				{
+					throw new ObjectDisposedException(Name);
+				}
+
+				if (!Equals(value, _value))
+				{
+					_value = value;
+
+					if (IsOnDispatcher)
+					{
+						_ = Task.Run(() => ValueChanged?.Invoke(this));
+					}
+					else
+					{
+						ValueChanged?.Invoke(this);
+					}
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public virtual event DynamicPropertyChangedEventHandler ValueChanged;
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			return Name + " " + Value;
+		}
+
+		protected virtual void Dispose(bool isDisposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			if (isDisposing)
+			{
+				_viewModel.SetTarget(null);
+				ValueChanged = null;
+			}
+
+			_isDisposed = true;
+
+			if (_diagnostics.IsEnabled("Disposed"))
+			{
+				_diagnostics.Write("Disposed", Name);
+			}
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			Dispose(isDisposing: true);
+
+			// If diagnostics are enabled, don't suppress the finalizer.
+			// This allows the differentiation between disposed and destroyed instances.
+			if (!_diagnostics.IsEnabled("Destroyed"))
+			{
+				GC.SuppressFinalize(this);
+			}
+		}
+
+		~ValueChangedOnBackgroundTaskDynamicProperty()
+		{
+			Dispose(isDisposing: false);
+
+			if (_diagnostics.IsEnabled("Destroyed"))
+			{
+				_diagnostics.Write("Destroyed", Name);
+			}
+		}
+	}
+
+	/// <summary>
+	/// This implementation of <see cref="IDynamicProperty{T}"/> ensures that <see cref="IDynamicProperty.ValueChanged"/> is raised on a background thread.
+	/// </summary>
+	public class ValueChangedOnBackgroundTaskDynamicProperty<T> : ValueChangedOnBackgroundTaskDynamicProperty, IDynamicProperty<T>
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicProperty{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="value">The initial value of this property.</param>
+		public ValueChangedOnBackgroundTaskDynamicProperty(string name, IViewModel viewModel, T value = default)
+			: base(name, viewModel, value)
+		{
+		}
+
+		/// <inheritdoc />
+		public new T Value
+		{
+			get => (T)base.Value;
+			set => base.Value = value;
+		}
+	}
+}

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chinook.DynamicMvvm.Implementations
+{
+	/// <summary>
+	/// This implementation of <see cref="IDynamicPropertyFactory"/> uses the <see cref="ValueChangedOnBackgroundTaskDynamicProperty"/> base class for all methods.
+	/// </summary>
+	public class ValueChangedOnBackgroundTaskDynamicPropertyFactory : IDynamicPropertyFactory
+	{
+		/// <inheritdoc/>
+		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
+		{
+			return new ValueChangedOnBackgroundTaskDynamicProperty<T>(name, viewModel, initialValue);
+		}
+
+		/// <inheritdoc/>
+		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
+		{
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T>(name, source, viewModel, initialValue);
+		}
+
+		/// <inheritdoc/>
+		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
+		{
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T>(name, source, viewModel, initialValue);
+		}
+	}
+}

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DynamicMvvm.Implementations
+{
+	/// <summary>
+	/// This is an implementation of a <see cref="IDynamicProperty{T}"/> using an <see cref="IObservable{T}"/> that ensures <see cref="IDynamicProperty.ValueChanged"/> is raised on a background thread.
+	/// </summary>
+	/// <typeparam name="T">Type of value</typeparam>
+	public class ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T> : ValueChangedOnBackgroundTaskDynamicProperty<T>
+	{
+		private readonly DynamicPropertyFromObservable<T>.DynamicPropertyObserver _propertyObserver;
+		private readonly IDisposable _subscription;
+		private bool _isDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromObservable{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="source">Source</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="initialValue">The initial value of this property.</param>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFromObservable(string name, IObservable<T> source, IViewModel viewModel, T initialValue = default)
+			: base(name, viewModel, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_propertyObserver = new DynamicPropertyFromObservable<T>.DynamicPropertyObserver(this);
+			_subscription = source.Subscribe(_propertyObserver);
+		}
+
+		/// <inheritdoc />
+		protected override void Dispose(bool isDisposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			if (isDisposing && _subscription != null)
+			{
+				_subscription.Dispose();
+			}
+
+			_isDisposed = true;
+
+			base.Dispose(isDisposing);
+		}
+	}
+}

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm.Implementations
+{
+	/// <summary>
+	/// This is an implementation of a <see cref="IDynamicProperty{T}"/> using a <see cref="Task{T}"/> that ensures <see cref="IDynamicProperty.ValueChanged"/> is raised on a background thread.
+	/// </summary>
+	/// <typeparam name="T">Type of value</typeparam>
+	public class ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T> : ValueChangedOnBackgroundTaskDynamicProperty<T>
+	{
+		private readonly CancellationTokenSource _cancellationTokenSource;
+		private bool _isDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromTask{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="source">The task source for this property.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="initialValue">The initial value of this property.</param>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, IViewModel viewModel, T initialValue = default)
+			: base(name, viewModel, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_cancellationTokenSource = new CancellationTokenSource();
+
+			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
+		}
+
+		private async Task SetValueFromSource(CancellationToken ct, Func<CancellationToken, Task<T>> source)
+		{
+			try
+			{
+				var value = await source(ct);
+
+				Value = value;
+			}
+			catch (Exception e)
+			{
+				this.Log().LogError(e, $"Source task failed for property '{Name}'.");
+			}
+		}
+
+		/// <inheritdoc />
+		protected override void Dispose(bool isDisposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			if (isDisposing)
+			{
+				_cancellationTokenSource.Cancel();
+				_cancellationTokenSource.Dispose();
+			}
+
+			_isDisposed = true;
+
+			base.Dispose(isDisposing);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## Description
- Add new implementations of `IDynamicProperty`.
  - `ValueChangedOnBackgroundTaskDynamicProperty` is an implementation that ensures that the `ValueChanged` event is raised on a background task (to avoid executing business logic on the `CoreDispatcher`).

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

