### PR TITLE
feat: Add Deactivation namespace

### DIFF
--- a/src/DynamicMvvm.Abstractions/AssemblyInfo.cs
+++ b/src/DynamicMvvm.Abstractions/AssemblyInfo.cs
@@ -2,4 +2,5 @@
 
 [assembly: InternalsVisibleTo("Chinook.DynamicMvvm")]
 [assembly: InternalsVisibleTo("Chinook.DynamicMvvm.FluentValidation")]
+[assembly: InternalsVisibleTo("Chinook.DynamicMvvm.Reactive")]
 [assembly: InternalsVisibleTo("Chinook.DynamicMvvm.Uno")]

--- a/src/DynamicMvvm.Abstractions/Deactivation/IDeactivatable.cs
+++ b/src/DynamicMvvm.Abstractions/Deactivation/IDeactivatable.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DynamicMvvm.Deactivation
+{
+	/// <summary>
+	/// Represents something that can be deactivated and reactivated.
+	/// </summary>
+	public interface IDeactivatable
+	{
+		/// <summary>
+		/// Gets whether this object is deactivated.
+		/// This is false by default.
+		/// </summary>
+		bool IsDeactivated { get; }
+
+		/// <summary>
+		/// Deactivates this object.
+		/// </summary>
+		void Deactivate();
+
+		/// <summary>
+		/// Reactivates this object.
+		/// </summary>
+		void Reactivate();
+	}
+}

--- a/src/DynamicMvvm.Abstractions/Deactivation/IDeactivatableViewModel.cs
+++ b/src/DynamicMvvm.Abstractions/Deactivation/IDeactivatableViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DynamicMvvm.Deactivation
+{
+	/// <summary>
+	/// Represents a ViewModel that implements deactivation.
+	/// </summary>
+	public interface IDeactivatableViewModel : IViewModel, IDeactivatable
+	{
+	}
+}

--- a/src/DynamicMvvm.Reactive/Deactivation/DeactivatableObservable.cs
+++ b/src/DynamicMvvm.Reactive/Deactivation/DeactivatableObservable.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm.Deactivation
+{
+	/// <summary>
+	/// This is an <see cref="IObservable{T}"/> than can be deactivated.
+	/// When deactivated, this observable unsubscribes from its inner source.
+	/// When reactivated, this observable re-subscribes to its inner source.
+	/// </summary>
+	/// <typeparam name="T">The type of data.</typeparam>
+	public class DeactivatableObservable<T> : IObservable<T>, IDeactivatable, IDisposable
+	{
+		private readonly IObservable<T> _source;
+
+		private IDisposable _subscription;
+		private IObserver<T> _observer;
+		private bool _isDisposingOrDisposed;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="DeactivatableObservable{T}"/>.
+		/// </summary>
+		/// <param name="source">The source that will be subscribed to when <see cref="IsDeactivated"/> is false.</param>
+		public DeactivatableObservable(IObservable<T> source)
+		{
+			_source = source ?? throw new ArgumentNullException(paramName: nameof(source));
+		}
+
+		/// <inheritdoc/>
+		public bool IsDeactivated { get; private set; } = false;
+
+		/// <inheritdoc/>
+		public IDisposable Subscribe(IObserver<T> observer)
+		{
+			if (_observer != null)
+			{
+				// This is sufficient for our use cases. Supporting more would complexify the code a lot.
+				throw new NotSupportedException("DeactivatableObservable only supports 1 subscription.");
+			}
+
+			_observer = observer;
+			_subscription = _source.Subscribe(observer);
+			return new CompositeDisposable(
+				_subscription,
+				Disposable.Create(() => _observer = null)
+			);
+		}
+
+		/// <inheritdoc/>
+		public void Deactivate()
+		{
+			if (IsDeactivated)
+			{
+				return;
+			}
+
+			_subscription?.Dispose();
+
+			IsDeactivated = true;
+
+			typeof(IDeactivatable).Log().LogDebug($"Deactivated observable of type '{typeof(T).Name}'.");
+		}
+
+		/// <inheritdoc/>
+		public void Reactivate()
+		{
+			if (!IsDeactivated)
+			{
+				return;
+			}
+
+			IsDeactivated = false;
+
+			if (_observer != null)
+			{
+				_subscription = _source.Subscribe(_observer);
+			}
+
+			typeof(IDeactivatable).Log().LogDebug($"Reactivated observable of type '{typeof(T).Name}'.");
+		}
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			if (_isDisposingOrDisposed)
+			{
+				return;
+			}
+
+			_isDisposingOrDisposed = true;
+			_subscription?.Dispose();
+		}
+	}
+}

--- a/src/DynamicMvvm.Reactive/Deactivation/IObservable.Extensions.cs
+++ b/src/DynamicMvvm.Reactive/Deactivation/IObservable.Extensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Chinook.DynamicMvvm.Deactivation;
+
+namespace System.Reactive.Linq
+{
+	/// <summary>
+	/// This class exposes extensions methods on <see cref="IObservable{T}"/> in the context of <see cref="Chinook.DynamicMvvm.Deactivation"/>.
+	/// </summary>
+	public static class ChinookDynamicMvvmDeactivationObservableExtensions
+	{
+		/// <summary>
+		/// Automatically disconnects <paramref name="source"/> when <paramref name="viewModel"/> deactivates.<br/>
+		/// Automatically reconnects <paramref name="source"/> when <paramref name="viewModel"/> reactivates.
+		/// </summary>
+		/// <typeparam name="T">The type of data.</typeparam>
+		/// <param name="source">The observable source.</param>
+		/// <param name="viewModel">The view model controlling the deactivation and reactivation of the observable.</param>
+		/// <returns>
+		/// An observable sequence that automatically disconnects and reconnects based on the state of <paramref name="viewModel"/>.
+		/// </returns>
+		public static IObservable<T> DeactivateWith<T>(this IObservable<T> source, IDeactivatableViewModel viewModel)
+		{
+			var deactivatableObservable = new DeactivatableObservable<T>(source);
+			viewModel.AddDisposable(Guid.NewGuid().ToString(), deactivatableObservable);
+			return deactivatableObservable;
+		}
+	}
+}

--- a/src/DynamicMvvm.Tests/Integration/DeactivationIntegrationTests.cs
+++ b/src/DynamicMvvm.Tests/Integration/DeactivationIntegrationTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm;
+using Chinook.DynamicMvvm.Deactivation;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.Integration
+{
+	public class DeactivationIntegrationTests
+	{
+		[Fact]
+		public void DeactivatableViewModelBase_works_with_DeactivatablePropertyFromObservable()
+		{
+			const string propertyName = nameof(TestVM.Count);
+			var countChanged = false;
+			var sut = new TestVM();
+
+			sut.PropertyChanged += OnPropertyChanged;
+			sut.Count.Should().Be(0);
+
+			// Update while activated. Updates should happen.
+			sut.CountSubject.OnNext(1);
+			ReadCountChanged().Should().BeTrue();
+			sut.CountSubject.HasObservers.Should().BeTrue();
+			sut.Count.Should().Be(1);
+
+			// Deactivate. Updates should not happen and observable should not be subscribed to.
+			sut.Deactivate();
+			sut.CountSubject.HasObservers.Should().BeFalse();
+
+			// Update while deactivated. 
+			sut.CountSubject.OnNext(2);
+			sut.Count.Should().Be(1);
+			ReadCountChanged().Should().BeFalse();
+
+			// Reactivate. The replay subject should be subscribed to and push an update.
+			sut.Reactivate();
+			ReadCountChanged().Should().BeTrue();
+			sut.CountSubject.HasObservers.Should().BeTrue();
+			sut.Count.Should().Be(2);
+
+			void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+			{
+				if (e.PropertyName == propertyName)
+				{
+					countChanged = true;
+				}
+			}
+
+			bool ReadCountChanged()
+			{
+				var value = countChanged;
+				countChanged = false;
+				return value;
+			}
+		}
+
+		public class TestVM : DeactivatableViewModelBase
+		{
+			public ReplaySubject<int> CountSubject = new ReplaySubject<int>(bufferSize: 1);
+
+			public int Count => this.GetFromDeactivatableObservable<int>(CountSubject, initialValue: 0);
+		}
+	}
+}

--- a/src/DynamicMvvm.Tests/Reactive/DeactivatableObservableTests.cs
+++ b/src/DynamicMvvm.Tests/Reactive/DeactivatableObservableTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm.Deactivation;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.Reactive
+{
+	public class DeactivatableObservableTests
+	{
+		[Fact]
+		public void Updates_are_paused_when_deactivated()
+		{
+			var updateCount = 0;
+			var subject = new ReplaySubject<int>(bufferSize: 1);
+			var sut = new DeactivatableObservable<int>(subject);
+
+			sut.Subscribe(OnNext);
+
+			updateCount.Should().Be(0);
+			subject.OnNext(0);
+			updateCount.Should().Be(1);
+
+			sut.Deactivate();
+
+			subject.OnNext(0);
+			// The previous update should not go through because the observable is deactivated.
+			updateCount.Should().Be(1);
+
+			sut.Reactivate();
+			// When we reactivate to the ReplaySubject, we should get an update (because it replays).
+			updateCount.Should().Be(2);
+
+			void OnNext(int obj)
+			{
+				++updateCount;
+			}
+		}
+	}
+}

--- a/src/DynamicMvvm.Tests/ViewModel/DeactivatableViewModelBaseTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/DeactivatableViewModelBaseTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm.Deactivation;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.ViewModel
+{
+	public class DeactivatableViewModelBaseTests
+	{
+		[Fact]
+		public void PropertyChanged_events_are_not_raised_while_deactivated_but_raised_when_reactivated()
+		{
+			var propertyChanges = new List<string>();
+			var sut = new DeactivatableViewModelBase();
+			sut.PropertyChanged += OnPropertyChanged;
+			sut.Deactivate();
+
+			sut.RaisePropertyChanged("Allo");
+			sut.RaisePropertyChanged("Hi");
+			sut.RaisePropertyChanged("Bonjour");
+
+			propertyChanges.Should().OnlyContain(s => s == "IsDeactivated");
+
+			sut.Reactivate();
+
+			propertyChanges.Should().Contain(new []{ "Allo", "Hi", "Bonjour"});
+
+			void OnPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+			{
+				propertyChanges.Add(e.PropertyName);
+			}
+		}
+	}
+}

--- a/src/DynamicMvvm/Deactivation/DeactivatableDynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Deactivation/DeactivatableDynamicPropertyFromObservable.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Chinook.DynamicMvvm.Implementations;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm.Deactivation
+{
+	/// <summary>
+	/// This is an implementation of a <see cref="IDynamicProperty{T}"/> using an <see cref="IObservable{T}"/> that
+	/// ensures <see cref="IDynamicProperty.ValueChanged"/> is raised on a background thread and its observable source can be deactivated.
+	/// </summary>
+	/// <typeparam name="T">Type of value</typeparam>
+	public class DeactivatableDynamicPropertyFromObservable<T> : ValueChangedOnBackgroundTaskDynamicProperty<T>, IDeactivatable
+	{
+		private readonly IObservable<T> _source;
+		private readonly DynamicPropertyFromObservable<T>.DynamicPropertyObserver _propertyObserver;
+
+		private IDisposable _subscription;
+		private bool _isDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DeactivatableDynamicPropertyFromObservable{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="source">The observable source.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="initialValue">The initial value of this property.</param>
+		public DeactivatableDynamicPropertyFromObservable(string name, IObservable<T> source, IViewModel viewModel, T initialValue = default)
+			: base(name, viewModel, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_source = source;
+			_propertyObserver = new DynamicPropertyFromObservable<T>.DynamicPropertyObserver(this);
+			_subscription = source.Subscribe(_propertyObserver);
+		}
+
+		/// <inheritdoc/>
+		public bool IsDeactivated { get; private set; } = false;
+
+		/// <inheritdoc />
+		protected override void Dispose(bool isDisposing)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			if (isDisposing && _subscription != null)
+			{
+				_subscription.Dispose();
+			}
+
+			_isDisposed = true;
+
+			base.Dispose(isDisposing);
+		}
+
+		/// <inheritdoc/>
+		public void Deactivate()
+		{
+			if (IsDeactivated)
+			{
+				return;
+			}
+
+			_subscription.Dispose();
+
+			IsDeactivated = true;
+
+			typeof(IDeactivatable).Log().LogDebug($"Deactivated observable source of property '{Name}'.");
+		}
+
+		/// <inheritdoc/>
+		public void Reactivate()
+		{
+			if (!IsDeactivated)
+			{
+				return;
+			}
+
+			IsDeactivated = false;
+
+			_subscription = _source.Subscribe(_propertyObserver);
+
+			typeof(IDeactivatable).Log().LogDebug($"Reactivated observable source of property '{Name}'.");
+		}
+	}
+}

--- a/src/DynamicMvvm/Deactivation/DeactivatableViewModelBase.cs
+++ b/src/DynamicMvvm/Deactivation/DeactivatableViewModelBase.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm.Deactivation
+{
+	/// <summary>
+	/// This is a default implementation of <see cref="IDeactivatableViewModel"/>.<br/>
+	/// When <see cref="IsDeactivated"/> is true, property changes are suppressed and buffered until <see cref="IDeactivatable.Reactivate"/> is called.
+	/// </summary>
+	public class DeactivatableViewModelBase : ViewModelBase, IDeactivatableViewModel
+	{
+		// This mutex protects the modifications on _changedProperties when IsDeactivated changes.
+		private readonly object _isDeactivatedMutex = new object();
+		private readonly HashSet<string> _changedProperties = new HashSet<string>();
+		private bool _isDeactivated = false;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DeactivatableViewModelBase"/> class.
+		/// </summary>
+		/// <param name="name">The name of the ViewModel.</param>
+		/// <param name="serviceProvider">The service provider.</param>
+		public DeactivatableViewModelBase(string name = null, IServiceProvider serviceProvider = null)
+			: base(name, serviceProvider)
+		{
+
+		}
+
+		/// <inheritdoc/>
+		public bool IsDeactivated
+		{
+			get => _isDeactivated;
+			private set
+			{
+				_isDeactivated = value;
+				if (!IsDisposed)
+				{
+					// Bypass the overridden implementation of RaisePropertyChanged so we can guarantee that the view will always be updated (e.g. Update even if IsDeactivated == true).
+					base.RaisePropertyChanged(nameof(IsDeactivated));
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		/// <remarks>
+		/// When <see cref="IsDeactivated"/> is true, property changes are suppressed and buffered until <see cref="IDeactivatable.Reactivate"/> is called.
+		/// </remarks>
+		public override void RaisePropertyChanged(string propertyName)
+		{
+			if (IsDeactivated)
+			{
+				lock (_isDeactivatedMutex)
+				{
+					_changedProperties.Add(propertyName);
+				}
+			}
+			else
+			{
+				base.RaisePropertyChanged(propertyName);
+			}
+		}
+
+		/// <summary>
+		/// Deactivates this ViewModel and all other <see cref="IDeactivatable"/> objects contained in <see cref="IViewModel.Disposables"/>.
+		/// </summary>
+		public virtual void Deactivate()
+		{
+			if (IsDeactivated)
+			{
+				return;
+			}
+
+			IsDeactivated = true;
+
+			var children = Disposables.Select(pair => pair.Value).OfType<IDeactivatable>();
+			foreach (var child in children)
+			{
+				child.Deactivate();
+			}
+
+			typeof(IDeactivatable).Log().LogDebug($"Deactivated ViewModel '{Name}'.");
+		}
+
+		/// <summary>
+		/// Reactivates this ViewModel and all other <see cref="IDeactivatable"/> objects contained in <see cref="IViewModel.Disposables"/>.
+		/// </summary>
+		public virtual void Reactivate()
+		{
+			if (!IsDeactivated)
+			{
+				return;
+			}
+
+			string[] toRaise;
+			lock (_isDeactivatedMutex)
+			{
+				IsDeactivated = false;
+				toRaise = _changedProperties.ToArray();
+				_changedProperties.Clear();
+			}
+
+			foreach (var propertyName in toRaise)
+			{
+				RaisePropertyChanged(propertyName);
+			}
+
+			var children = Disposables.Select(pair => pair.Value).OfType<IDeactivatable>().ToList();
+			foreach (var child in children)
+			{
+				child.Reactivate();
+			}
+
+			typeof(IDeactivatable).Log().LogDebug($"Reactivated ViewModel '{Name}' and raised {toRaise.Length} property changes.");
+		}
+	}
+}

--- a/src/DynamicMvvm/Deactivation/IDeactivatableViewModel.Extensions.cs
+++ b/src/DynamicMvvm/Deactivation/IDeactivatableViewModel.Extensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Chinook.DynamicMvvm.Deactivation;
+
+namespace Chinook.DynamicMvvm
+{
+	/// <summary>
+	/// This class exposes extensions methods on <see cref="IDeactivatableViewModel"/>.
+	/// </summary>
+	public static class DeactivatableViewModelExtensions
+	{
+		/// <summary>
+		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.<br/>
+		/// The underlying <see cref="IDynamicProperty"/> implements <see cref="IDeactivatable"/> so the observation can be deactivated.
+		/// </summary>
+		/// <typeparam name="T">The property type.</typeparam>
+		/// <param name="viewModel">The <see cref="IViewModel"/> owning the property.</param>
+		/// <param name="source">The observable of values that feeds the property.</param>
+		/// <param name="initialValue">The property's initial value.</param>
+		/// <param name="name">The property's name.</param>
+		/// <returns>The property's value.</returns>
+		public static T GetFromDeactivatableObservable<T>(this IDeactivatableViewModel viewModel, IObservable<T> source, T initialValue = default, [CallerMemberName] string name = null)
+		{
+			return viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => new DeactivatableDynamicPropertyFromObservable<T>(name, source, viewModel, initialValue)));
+		}
+	}
+}

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.cs
@@ -18,8 +18,8 @@ namespace Chinook.DynamicMvvm
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ViewModelBase"/> class.
 		/// </summary>
-		/// <param name="name"></param>
-		/// <param name="serviceProvider"></param>
+		/// <param name="name">The name of the ViewModel.</param>
+		/// <param name="serviceProvider">The service provider.</param>
 		public ViewModelBase(string name = null, IServiceProvider serviceProvider = null)
 		{
 			Name = name ?? GetType().Name;


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## Description

Introduce new interfaces and some implementations for performance optimization.
Implement `IDeactivatable` on a reactive object (like a ViewModel, a dynamic property or an observable) to temporarily deactivate it to prevent updates that would cause unnecessary processing.

Example: if a page ViewModel exists in the navigation stack, but isn't the top-most one, it is still raising events like PropertyChanged to update data bindings, but no one sees the view bound to that data.

- Add `IDeactivatable` and `IDeactivatableViewModel`
- Add `DeactivatableObservable<T>`, an `IObservable` wrapper that allows _pausing_ the observable subscription.
- Add `DeactivatableDynamicPropertyFromObservable<T>`, a dynamic property from observable that allows _pausing_ the observable subscription.
- Add `DeactivatableViewModelBase`, a derivative of the existing `ViewModelBase` that doesn't raise `PropertyChanged` while deactivated.


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

