### PR TITLE
build: Add SourceLink workaround for AssemblyInfo

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,9 @@
+<!-- This is a SourceLink workaround documented here: https://github.com/clairernovotny/DeterministicBuilds#work-around-for-net-sdk-prior-31300 -->
+<Project>
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Build or CI related changes 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

The [SourceLink workaround](https://github.com/clairernovotny/DeterministicBuilds#work-around-for-net-sdk-prior-31300) is not there.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The [SourceLink workaround](https://github.com/clairernovotny/DeterministicBuilds#work-around-for-net-sdk-prior-31300) is there.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

