### PR TITLE
fix: Add missing Preserve attribute on ValueChangedOnBackgroundTaskDy…

### DIFF
--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
@@ -9,6 +9,7 @@ namespace Chinook.DynamicMvvm.Implementations
 	/// <summary>
 	/// This implementation of <see cref="IDynamicPropertyFactory"/> uses the <see cref="ValueChangedOnBackgroundTaskDynamicProperty"/> base class for all methods.
 	/// </summary>
+	[Preserve(AllMembers = true)]
 	public class ValueChangedOnBackgroundTaskDynamicPropertyFactory : IDynamicPropertyFactory
 	{
 		/// <inheritdoc/>


### PR DESCRIPTION
…namicPropertyFactory

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

`ValueChangedOnBackgroundTaskDynamicPropertyFactory` doesn't have a `Preserve` attribute.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

`ValueChangedOnBackgroundTaskDynamicPropertyFactory` has a `Preserve` attribute.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

