### PR TITLE
feat: Add RaiseCanExecuteOnDispatcherCommandStrategy + tests

### DIFF
--- a/src/DynamicMvvm.Tests/Command/Strategies/RaiseCanExecuteOnDispatcherCommandStrategyTests.cs
+++ b/src/DynamicMvvm.Tests/Command/Strategies/RaiseCanExecuteOnDispatcherCommandStrategyTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm.Tests.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.Command.Strategies
+{
+	public class RaiseCanExecuteOnDispatcherCommandStrategyTests
+	{
+		[Fact]
+		public void Requires_a_non_null_ViewModel()
+		{
+			Assert.Throws<ArgumentNullException>(() => new RaiseCanExecuteOnDispatcherCommandStrategy(viewModel: null));
+		}
+
+		[Fact]
+		public void Dispatches_to_view_when_not_already_on_dispatcher()
+		{
+			var vm = new ViewModelBase();
+			var sut = new RaiseCanExecuteOnDispatcherCommandStrategy(vm);
+			var inner = new TestCommandStrategy();
+			var dispatched = false;
+			sut.InnerStrategy = inner;
+
+			vm.View = new TestViewModelView(hasDispatcherAccess: false, OnExecuteOnDispatcher);
+
+			inner.RaiseCanExecuteChanged();
+
+			dispatched.Should().BeTrue();
+			
+			void OnExecuteOnDispatcher(Action action)
+			{
+				dispatched = true;
+				action();
+			}
+		}
+
+		[Fact]
+		public void Does_not_dispatch_to_view_when_already_on_dispatcher()
+		{
+			var vm = new ViewModelBase();
+			var sut = new RaiseCanExecuteOnDispatcherCommandStrategy(vm);
+			var inner = new TestCommandStrategy();
+			var dispatched = false;
+			sut.InnerStrategy = inner;
+
+			vm.View = new TestViewModelView(hasDispatcherAccess: true, OnExecuteOnDispatcher);
+
+			inner.RaiseCanExecuteChanged();
+
+			dispatched.Should().BeFalse();
+
+			void OnExecuteOnDispatcher(Action action)
+			{
+				dispatched = true;
+				action();
+			}
+		}
+
+		[Fact]
+		public void Raises_even_if_view_is_null()
+		{
+			var vm = new ViewModelBase();
+			var sut = new RaiseCanExecuteOnDispatcherCommandStrategy(vm);
+			var inner = new TestCommandStrategy();
+			var raised = false;
+			sut.InnerStrategy = inner;
+			sut.CanExecuteChanged += OnCanExecuteChanged;
+
+			inner.RaiseCanExecuteChanged();
+
+			raised.Should().BeTrue();
+
+			void OnCanExecuteChanged(object sender, EventArgs e)
+			{
+				raised = true;
+			}
+		}
+
+	}
+}

--- a/src/DynamicMvvm/Command/DynamicCommandBuilderFactory.cs
+++ b/src/DynamicMvvm/Command/DynamicCommandBuilderFactory.cs
@@ -27,6 +27,7 @@ namespace Chinook.DynamicMvvm
 		/// </summary>
 		/// <param name="name">Command name</param>
 		/// <param name="strategy"><see cref="IDynamicCommandStrategy"/></param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> that will own the newly created command.</param>
 		/// <returns><see cref="IDynamicCommandBuilder"/></returns>
 		protected IDynamicCommandBuilder CreateBuilder(string name, IDynamicCommandStrategy strategy, IViewModel viewModel)
 		{

--- a/src/DynamicMvvm/Command/Strategies/RaiseCanExecuteOnDispatcherCommandStrategy.cs
+++ b/src/DynamicMvvm/Command/Strategies/RaiseCanExecuteOnDispatcherCommandStrategy.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Chinook.DynamicMvvm;
+
+namespace Chinook.DynamicMvvm
+{
+	/// <summary>
+	/// This <see cref="IDynamicCommandStrategy"/> ensures that the <see cref="CanExecuteChanged"/> event is raised using <see cref="IViewModelView.ExecuteOnDispatcher(CancellationToken, Action)"/>.
+	/// </summary>
+	public class RaiseCanExecuteOnDispatcherCommandStrategy : DecoratorCommandStrategy
+	{
+		private readonly WeakReference<IViewModel> _viewModel;
+		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+		/// <summary>
+		/// Creates a new instance of <see cref="RaiseCanExecuteOnDispatcherCommandStrategy"/>.
+		/// </summary>
+		/// <param name="viewModel">The <see cref="IViewModel"/> from which to access the <see cref="IViewModelView"/>.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="viewModel"/> cannot be null.</exception>
+		public RaiseCanExecuteOnDispatcherCommandStrategy(IViewModel viewModel)
+		{
+			if (viewModel is null)
+			{
+				throw new ArgumentNullException(nameof(viewModel));
+			}
+
+			_viewModel = new WeakReference<IViewModel>(viewModel);
+		}
+
+		/// <inheritdoc/>
+		public override IDynamicCommandStrategy InnerStrategy
+		{
+			get => base.InnerStrategy;
+			set
+			{
+				if (base.InnerStrategy != null)
+				{
+					base.InnerStrategy.CanExecuteChanged -= OnInnerCanExecuteChanged;
+				}
+
+				base.InnerStrategy = value;
+
+				if (base.InnerStrategy != null)
+				{
+					base.InnerStrategy.CanExecuteChanged += OnInnerCanExecuteChanged;
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		public override event EventHandler CanExecuteChanged;
+
+		private void OnInnerCanExecuteChanged(object sender, EventArgs e)
+		{
+			var hasVM = _viewModel.TryGetTarget(out var viewModel);
+
+			if (!hasVM || viewModel.IsDisposed)
+			{
+				return;
+			}
+
+			// The event should be raised immediately when the view already has dispatcher access OR when there is no view.
+			var shouldDispatch = viewModel.View?.GetHasDispatcherAccess() ?? true;
+
+			if (shouldDispatch)
+			{
+				RaiseCanExecuteChanged();
+			}
+			else
+			{
+				_ = viewModel.View.ExecuteOnDispatcher(_cts.Token, RaiseCanExecuteChanged);
+			}
+
+			void RaiseCanExecuteChanged()
+			{
+				CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		/// <inheritdoc/>
+		public override void Dispose()
+		{
+			base.Dispose();
+
+			_cts.Cancel();
+			_cts.Dispose();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## Description
Add `RaiseCanExecuteOnDispatcherCommandStrategy`, a strategy that ensures that `CanExecuteChanged` is raised on the dispatcher when possible.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

