### PR TITLE
fix: Do not use Token from source when it could be disposed or canceled.

### DIFF
--- a/src/DynamicMvvm/Command/DynamicCommand.cs
+++ b/src/DynamicMvvm/Command/DynamicCommand.cs
@@ -17,6 +17,7 @@ namespace Chinook.DynamicMvvm
 		private static readonly DiagnosticSource _diagnostics = new DiagnosticListener("Chinook.DynamicMvvm.IDynamicCommand");
 
 		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+		private readonly CancellationToken _cancellationToken;
 		private readonly IDynamicCommandStrategy _strategy;
 		private int _executions;
 		private bool _isDisposed;
@@ -28,6 +29,8 @@ namespace Chinook.DynamicMvvm
 		/// <param name="strategy"><see cref="IDynamicCommandStrategy"/></param>
 		public DynamicCommand(string name, IDynamicCommandStrategy strategy)
 		{
+			_cancellationToken = _cancellationTokenSource.Token;
+			
 			Name = name;
 
 			_strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
@@ -81,7 +84,7 @@ namespace Chinook.DynamicMvvm
 				{
 					IncrementExecutions();
 
-					await _strategy.Execute(_cancellationTokenSource.Token, parameter, this);
+					await _strategy.Execute(_cancellationToken, parameter, this);
 				}
 				finally
 				{


### PR DESCRIPTION
Experienced exception:
```
2022-05-11 17:04:39.502-05:00 [iOS] E/Chinook.DynamicMvvm.DynamicCommand: Command execution of 'CancelOrderCommand' failed. Consider using ErrorHandlerCommandStrategy. System.ObjectDisposedException: The CancellationTokenSource has been disposed.
  at Chinook.DynamicMvvm.DynamicCommand.Execute (System.Object parameter) <0x108a17960 + 0x000b4> in <3d2a802c306f4231ab13f6010871dd04#6652506b31245340bd69ac67286bdef4>:0 
```

## Proposed Changes

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
Throws exception when executing dynamic command which is disposed.


## What is the new behavior?
 Store token when object is created to not access it later when source gets cancelled or disposed.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue