### PR TITLE
fix: Improve log message when executing a disposed command

### DIFF
--- a/src/DynamicMvvm.Tests/Command/DynamicCommandTests.cs
+++ b/src/DynamicMvvm.Tests/Command/DynamicCommandTests.cs
@@ -284,5 +284,35 @@ namespace Chinook.DynamicMvvm.Tests.Command
 
 			taskCompletionSource.Task.IsCanceled.Should().BeTrue();
 		}
+
+		[Fact]
+		public async Task It_Doesnt_Execute_When_Disposed()
+		{
+			var didExecute = false;
+			var didIsExecutingChanged = false;
+			var strategy = new TestCommandStrategy(
+				onExecute: async (ct, _, __) =>
+				{
+					didExecute = true;
+				}
+			);
+
+			var command = new DynamicCommand(DefaultCommandName, strategy);
+			command.IsExecutingChanged += OnIsExecutingChanged;
+			
+			command.Dispose();
+			
+			var commandExecution = command.Execute();
+
+			await commandExecution;
+
+			didExecute.Should().BeFalse();
+			didIsExecutingChanged.Should().BeFalse();
+			
+			void OnIsExecutingChanged(object sender, EventArgs e)
+			{
+				didIsExecutingChanged = true;
+			}
+		}
 	}
 }

--- a/src/DynamicMvvm/Command/DynamicCommand.cs
+++ b/src/DynamicMvvm/Command/DynamicCommand.cs
@@ -72,6 +72,13 @@ namespace Chinook.DynamicMvvm
 		{
 			try
 			{
+				if (_isDisposed)
+				{
+					// Note that we don't throw an ObjectDisposedException here because we're likely on a UI thread.
+					this.Log().LogError("Failed to execute command '{Name}' because it's disposed.", Name);
+					return;
+				}
+
 				if (!CanExecute(parameter))
 				{
 					return;


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

When executing a disposed `DynamicCommand`, the `IDynamicCommand.IsExecutingChanged` is raised and we get an error log about `_cancellationTokenSource` being disposed.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

When executing a disposed `DynamicCommand`, the `IDynamicCommand.IsExecutingChanged` is no longer raised and we get an error log about saying that the command is disposed.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

