### PR TITLE
feat: Add helpful log message when PropertyChanged fails.

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -52,7 +52,16 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			try
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+			catch (Exception exception) when (View is null)
+			{
+				// Give some details and tips on how to fix the issue.
+				_logger.LogError(exception, "Failed to raise PropertyChanged. Make sure you link child viewmodels to their parent by using one of the following IViewModel extension method: AttachChild, GetChild, AttachOrReplaceChild.");
+				throw;
+			}
 
 			_logger.LogDebug($"Raised property changed for '{propertyName}' from ViewModel '{Name}'.");
 		}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

When a child ViewModel is not attached to its parent using `AttachChild`, `GetChild` or `AttachOrReplaceChild`, the UI-thread-related exception doesn't hint the missing relationship between child and parent ViewModels.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The UI-thread-related exception is followed by a helpful error log that hints the solution.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

