### PR TITLE
fix: Remove the WeakReference around the ViewModelBase.Dispatcher now…

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Dispatcher.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Dispatcher.cs
@@ -7,24 +7,17 @@ namespace Chinook.DynamicMvvm
 {
 	public partial class ViewModelBase
 	{
-		private readonly WeakReference<IDispatcher> _dispatcher = new WeakReference<IDispatcher>(default);
+		private IDispatcher _dispatcher;
 
 		/// <inheritdoc />
 		public IDispatcher Dispatcher
 		{
-			get => GetDispatcher();
+			get => _dispatcher;
 			set => SetDispatcher(value);
 		}
 
 		/// <inheritdoc />
 		public event Action<IDispatcher> DispatcherChanged;
-
-		private IDispatcher GetDispatcher()
-		{
-			return _dispatcher != null && _dispatcher.TryGetTarget(out var dispatcher)
-				? dispatcher
-				: (default);
-		}
 
 		private void SetDispatcher(IDispatcher dispatcher)
 		{
@@ -34,7 +27,7 @@ namespace Chinook.DynamicMvvm
 				ThrowIfDisposed();
 			}
 
-			_dispatcher.SetTarget(dispatcher);
+			_dispatcher = dispatcher;
 
 			if (_isDisposing)
 			{

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -103,7 +103,7 @@ namespace Chinook.DynamicMvvm
 					}
 				}
 
-				_dispatcher.SetTarget(null);
+				_dispatcher = null;
 				_disposables.Clear();
 			}
 

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -26,11 +26,9 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
-			var viewModelView = GetDispatcher();
-
-			if (viewModelView != null && !viewModelView.GetHasDispatcherAccess())
+			if (Dispatcher != null && !Dispatcher.GetHasDispatcherAccess())
 			{
-				_ = viewModelView.ExecuteOnDispatcher(CancellationToken, () => RaisePropertyChangedInner(propertyName));
+				_ = Dispatcher.ExecuteOnDispatcher(CancellationToken, () => RaisePropertyChangedInner(propertyName));
 			}
 			else
 			{


### PR DESCRIPTION
… that Dispatcher doesn't hold a reference on a FrameworkElement.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

References to ViewModelBase.Dispatcher can be lost.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

References to ViewModelBase.Dispatcher cannot be lost.
`IViewModelView` required a `WeakReference` because we would otherwise keep a reference on a `FrameworkElement`. This is no longer needed with `IDispatcher` because it doesn't reference a `FrameworkElement`.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

