### PR TITLE
ci: Set gitversion to MainLine mode.

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -3,19 +3,17 @@
 # Only builds from master and feature/* are pushed to nuget.org.
 
 assembly-versioning-scheme: MajorMinorPatch
-mode: ContinuousDeployment
-next-version: 0.12.0
+mode: MainLine
+next-version: '' # Use git tags to set the base version.
 continuous-delivery-fallback-tag: ""
 commit-message-incrementing: Enabled
 major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
 minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
 patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
-increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:
   master:
     regex: ^master$|^main$
     tag: ''
-    increment: none
   dev:
     regex: dev/.*?/(.*?)
     tag: dev.{BranchName}
@@ -24,6 +22,5 @@ branches:
     tag: feature.{BranchName}
     regex: feature/(.*?)
     source-branches: [master]
-    increment: none
 ignore:
   sha: []


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

GitVersion mode is set to ContinuousDeployment.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
GitVersion mode is set to MainLine.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] You conventional commit are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

