### PR TITLE
ci: Don't automatically run the pipeline on feature branches.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,11 +27,14 @@ GitHub Issue: #
   - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
   - Public members were removed or renamed.
   - Public method signatures were changed or renamed.
-- [ ] **Minor** (Public API was extended)
+- [ ] **Minor** (Public API was extended.)
   - Public constructs, members, or overloads were added.
 - [ ] **Patch** (Public API was unchanged.)
   - A bug in behavior was fixed.
   - Documentation was changed.
+- [ ] **None** (The library is unchanged.)
+  - Only code under the `build` folder was changed.
+  - Only code under the `.github` folder was changed.
 
 ## Checklist
 
@@ -40,7 +43,7 @@ Please check that your PR fulfills the following requirements:
 - [ ] Documentation has been added/updated.
 - [ ] Automated Unit / Integration tests for the changes have been added/updated.
 - [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
-- [ ] You conventional commit are aligned with the **Impact on version** section.
+- [ ] Your conventional commits are aligned with the **Impact on version** section.
 
 <!-- If this PR contains a breaking change, please describe the impact
      and migration path for existing applications below. -->

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -2,7 +2,6 @@
   branches:
     include:
     - main
-    - feature/*
 
 resources:
    containers:


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
Feature branches automatically release packages.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Feature branches don't automatically release packages.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [x] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

