### PR TITLE
fix: Fix a possible concurrency issue when adding disposables while a…

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -41,6 +41,12 @@ namespace Chinook.DynamicMvvm
 
 			ThrowIfDisposed();
 
+			if (_isDisposing)
+			{
+				_logger.LogDebug("Skipped '{MethodName}' for key '{DisposableKey}' on ViewModel '{ViewModelName}' because it's disposing.", nameof(AddDisposable), key, Name);
+				return;
+			}
+
 			_disposables.Add(key, disposable);
 		}
 
@@ -51,7 +57,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				// No need to remove the disposable if the VM is disposing because the disposables will be cleared.
+				// No need to remove the disposable while the VM is disposing because the disposables will be cleared.
 				return;
 			}
 


### PR DESCRIPTION
… VM is being disposed.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Adding a disposable to a `ViewModelBase` while disposing it at the same time (using 2 threads) can lead to the following exception.
```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
```

## What is the new behavior?
Adding a disposable to a `ViewModelBase` while disposing it at the same time does nothing (except logging a debug message informing that the method was skipped).


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

