### PR TITLE
fix: Don't set the Dispatcher to null when detaching child VMs.

### DIFF
--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Children.cs
@@ -121,7 +121,6 @@ namespace Chinook.DynamicMvvm
 				throw new ArgumentNullException(nameof(childViewModel));
 			}
 
-			childViewModel.Dispatcher = null;
 			if (childViewModel.TryGetDisposable(ParentDispatcherChangedSubscriptionKey, out var subscription))
 			{
 				subscription.Dispose();
@@ -168,9 +167,9 @@ namespace Chinook.DynamicMvvm
 				_parentViewModel.DispatcherChanged += OnParentDispatcherChanged;
 			}
 
-			private void OnParentDispatcherChanged(IDispatcher view)
+			private void OnParentDispatcherChanged(IDispatcher dispatcher)
 			{
-				_childViewModel.Dispatcher = view;
+				_childViewModel.Dispatcher = dispatcher;
 			}
 
 			public void Dispose()

--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
@@ -128,6 +128,24 @@ namespace Chinook.DynamicMvvm.Tests.ViewModel
 		}
 
 		[Fact]
+		public void It_Keeps_The_Dispatcher_When_Detached()
+		{
+			// We can't assume that the dispatcher is no longer relevant when detaching children.
+			// For example, if a view is still subscribed to PropertyChanged, the property changes must still happen on the dispatcher, even if the child is detached.
+
+			var parentViewModel = new ViewModelBase();
+			var childViewModel = new TestViewModel();
+
+			parentViewModel.AttachChild(childViewModel);
+
+			parentViewModel.Dispatcher = new TestDispatcher();
+
+			parentViewModel.DetachChild(childViewModel);
+
+			childViewModel.Dispatcher.Should().Be(parentViewModel.Dispatcher);
+		}
+
+		[Fact]
 		public void It_Attaches_Multiple_Children()
 		{
 			var parentViewModel = new ViewModelBase();


### PR DESCRIPTION
... Let Dispose do it at the right time.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
`DetachChild` sets the `IViewModel.Dispatcher` to null. This can lead to incorrect behaviors when the view is still subscribed to `PropertyChanged`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
`DetachChild` no longer sets `IViewModel.Dispatcher` to null.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

