### PR TITLE
Introducing ThrowOnDisposed on IDynamicPropety implementations

### DIFF
--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyFactoryTests.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyFactoryTests.cs
@@ -80,5 +80,50 @@ namespace Chinook.DynamicMvvm.Tests.Property
 
 			property.Value.Should().Be(myValue);
 		}
+
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public void It_Creates_Property_That_Throws_On_Set_When_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
+		{
+			// Arrange
+			var factory = new DynamicPropertyFactory(throwOnDisposed);
+
+			var taskProperty = factory.CreateFromTask(DefaultPropertyName, _ => Task.FromResult(new TestEntity()), new TestEntity());
+			var obProperty = factory.CreateFromObservable(DefaultPropertyName, new Subject<TestEntity>(), new TestEntity());
+			var property = factory.Create(DefaultPropertyName, new TestEntity());
+
+			// Act
+			taskProperty.Dispose();
+			obProperty.Dispose();
+			property.Dispose();
+
+			Action actTask = () =>
+			{
+				taskProperty.Value = new TestEntity();
+			};
+			Action actOb = () =>
+			{
+				obProperty.Value = new TestEntity();
+			};
+			Action actP = () =>
+			{
+				property.Value = new TestEntity();
+			};
+
+			// Assert
+			if (throwOnDisposed)
+			{
+				actTask.Should().Throw<InvalidOperationException>();
+				actOb.Should().Throw<InvalidOperationException>();
+				actP.Should().Throw<InvalidOperationException>();
+			}
+			else
+			{
+				actTask.Should().NotThrow();
+				actOb.Should().NotThrow();
+				actP.Should().NotThrow();
+			}
+		}
 	}
 }

--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.T.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.T.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Chinook.DynamicMvvm.Tests.Helpers;
 using Xunit;
@@ -81,15 +79,31 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			}
 		}
 
-		[Fact]
-		public void It_Throws_When_Value_Set_After_Disposed()
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public void It_Throws_When_Value_Set_After_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
 		{
+			// Arrange
 			var receivedValues = new List<IDynamicProperty>();
-			var property = new DynamicProperty<TestEntity>(DefaultPropertyName);
+			var property = new DynamicProperty<TestEntity>(DefaultPropertyName, throwOnDisposed: throwOnDisposed);
 
+			// Act
 			property.Dispose();
+			Action act = () =>
+			{
+				property.Value = new TestEntity();
+			};
 
-			Assert.Throws<ObjectDisposedException>(() => property.Value = new TestEntity());
+			// Assert
+			if (throwOnDisposed)
+			{
+				act.Should().Throw<ObjectDisposedException>();
+			}
+			else
+			{
+				act.Should().NotThrow();
+			}
 		}
 
 		[Fact]

--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
-using Chinook.DynamicMvvm;
 using Xunit;
 
 namespace Chinook.DynamicMvvm.Tests.Property
@@ -78,6 +75,32 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			void OnValueChanged(IDynamicProperty p)
 			{
 				receivedValues.Add(p);
+			}
+		}
+
+		[Theory]
+		[InlineData(true)]
+		[InlineData(false)]
+		public void It_Throws_When_Value_Set_After_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
+		{
+			// Arrange
+			var property = new DynamicProperty(DefaultPropertyName, throwOnDisposed: throwOnDisposed);
+
+			// Act
+			property.Dispose();
+			Action act = () =>
+			{
+				property.Value = new object();
+			};
+
+			// Assert
+			if (throwOnDisposed)
+			{
+				act.Should().Throw<ObjectDisposedException>();
+			}
+			else
+			{
+				act.Should().NotThrow();
 			}
 		}
 

--- a/src/DynamicMvvm/Property/DynamicProperty.T.cs
+++ b/src/DynamicMvvm/Property/DynamicProperty.T.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Chinook.DynamicMvvm
 {
@@ -12,6 +10,9 @@ namespace Chinook.DynamicMvvm
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicProperty{T}"/> class.
 		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
 		/// <param name="name">Name</param>
 		/// <param name="value">Initial value</param>
 		public DynamicProperty(string name, T value = default)
@@ -19,9 +20,20 @@ namespace Chinook.DynamicMvvm
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicProperty{T}"/> class.
+		/// </summary>
+		/// <param name="name">Name</param>
+		/// <param name="value">Initial value</param>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="Value"/> is changed after being disposed.</param>
+		public DynamicProperty(string name, bool throwOnDisposed, T value = default)
+			: base(name, throwOnDisposed, value)
+		{
+		}
+
 		/// <inheritdoc />
-		public new T Value 
-		{ 
+		public new T Value
+		{
 			get => (T)((DynamicProperty)this).Value;
 			set => ((DynamicProperty)this).Value = value;
 		}

--- a/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,16 +13,38 @@ namespace Chinook.DynamicMvvm
 	[Preserve(AllMembers = true)]
 	public class DynamicPropertyFactory : IDynamicPropertyFactory
 	{
+		private readonly bool _throwOnDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
+		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
+		public DynamicPropertyFactory()
+		{
+			_throwOnDisposed = true;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
+		/// </summary>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public DynamicPropertyFactory(bool throwOnDisposed)
+		{
+			_throwOnDisposed = throwOnDisposed;
+		}
+
 		/// <inheritdoc />
 		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicProperty<T>(name, initialValue);
+			=> new DynamicProperty<T>(name, _throwOnDisposed, initialValue);
 
 		/// <inheritdoc />
 		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicPropertyFromTask<T>(name, source, initialValue);
+			=> new DynamicPropertyFromTask<T>(name, source, _throwOnDisposed, initialValue);
 
 		/// <inheritdoc />
 		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicPropertyFromObservable<T>(name, source, initialValue);
+			=> new DynamicPropertyFromObservable<T>(name, source, _throwOnDisposed, initialValue);
 	}
 }

--- a/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
@@ -18,11 +18,33 @@ namespace Chinook.DynamicMvvm
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFromObservable{T}"/> class.
 		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
 		/// <param name="name">Name</param>
 		/// <param name="source">Source</param>
 		/// <param name="initialValue">Initial value</param>
 		public DynamicPropertyFromObservable(string name, IObservable<T> source, T initialValue = default)
 			: base(name, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_propertyObserver = new DynamicPropertyObserver(this);
+			_subscription = source.Subscribe(_propertyObserver);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFromObservable{T}"/> class.
+		/// </summary>
+		/// <param name="name">Name</param>
+		/// <param name="source">Source</param>
+		/// <param name="initialValue">Initial value</param>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public DynamicPropertyFromObservable(string name, IObservable<T> source, bool throwOnDisposed, T initialValue = default)
+			: base(name, throwOnDisposed, initialValue)
 		{
 			if (source is null)
 			{

--- a/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -19,6 +17,9 @@ namespace Chinook.DynamicMvvm
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFromTask{T}"/> class.
 		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
 		/// <param name="name">Name</param>
 		/// <param name="source">Source</param>
 		/// <param name="initialValue">Initial value</param>
@@ -31,7 +32,27 @@ namespace Chinook.DynamicMvvm
 			}
 
 			_cancellationTokenSource = new CancellationTokenSource();
-			
+
+			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFromTask{T}"/> class.
+		/// </summary>
+		/// <param name="name">Name</param>
+		/// <param name="source">Source</param>
+		/// <param name="initialValue">Initial value</param>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public DynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, bool throwOnDisposed, T initialValue = default)
+			: base(name, throwOnDisposed, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_cancellationTokenSource = new CancellationTokenSource();
+
 			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
 		}
 

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,22 +10,44 @@ namespace Chinook.DynamicMvvm.Implementations
 	[Preserve(AllMembers = true)]
 	public class ValueChangedOnBackgroundTaskDynamicPropertyFactory : IDynamicPropertyFactory
 	{
+		private readonly bool _throwOnDisposed;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
+		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFactory()
+		{
+			_throwOnDisposed = true;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
+		/// </summary>
+		/// <param name="throwOnDisposed">Whether a <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFactory"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFactory(bool throwOnDisposed = true)
+		{
+			_throwOnDisposed = throwOnDisposed;
+		}
+
 		/// <inheritdoc/>
 		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicProperty<T>(name, viewModel, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicProperty<T>(name, viewModel, _throwOnDisposed, initialValue);
 		}
 
 		/// <inheritdoc/>
 		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T>(name, source, viewModel, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T>(name, source, viewModel, _throwOnDisposed, initialValue);
 		}
 
 		/// <inheritdoc/>
 		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T>(name, source, viewModel, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T>(name, source, viewModel, _throwOnDisposed, initialValue);
 		}
 	}
 }

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Chinook.DynamicMvvm.Implementations
 {
@@ -17,12 +15,35 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromObservable{T}"/> class.
 		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
 		/// <param name="name">The name of the this property.</param>
 		/// <param name="source">Source</param>
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="initialValue">The initial value of this property.</param>
 		public ValueChangedOnBackgroundTaskDynamicPropertyFromObservable(string name, IObservable<T> source, IViewModel viewModel, T initialValue = default)
 			: base(name, viewModel, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_propertyObserver = new DynamicPropertyFromObservable<T>.DynamicPropertyObserver(this);
+			_subscription = source.Subscribe(_propertyObserver);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromObservable{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="source">Source</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="initialValue">The initial value of this property.</param>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFromObservable(string name, IObservable<T> source, IViewModel viewModel, bool throwOnDisposed, T initialValue = default)
+			: base(name, viewModel, throwOnDisposed, initialValue)
 		{
 			if (source is null)
 			{

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -19,12 +17,36 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromTask{T}"/> class.
 		/// </summary>
+		/// <remarks>
+		/// When setting <see cref="IDynamicProperty.Value"/> after being disposed, <see cref="ObjectDisposedException"/> will be thrown.
+		/// </remarks>
 		/// <param name="name">The name of the this property.</param>
 		/// <param name="source">The task source for this property.</param>
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="initialValue">The initial value of this property.</param>
 		public ValueChangedOnBackgroundTaskDynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, IViewModel viewModel, T initialValue = default)
 			: base(name, viewModel, initialValue)
+		{
+			if (source is null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			_cancellationTokenSource = new CancellationTokenSource();
+
+			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromTask{T}"/> class.
+		/// </summary>
+		/// <param name="name">The name of the this property.</param>
+		/// <param name="source">The task source for this property.</param>
+		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
+		/// <param name="initialValue">The initial value of this property.</param>
+		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		public ValueChangedOnBackgroundTaskDynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, IViewModel viewModel, bool throwOnDisposed, T initialValue = default)
+			: base(name, viewModel, throwOnDisposed, initialValue)
 		{
 			if (source is null)
 			{


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
By default, when trying to set a disposed property, it will throw a `ObjectDisposedException`.

## What is the new behavior?
We provide the option to configure `IDynamicProperty` implementations to prevent exceptions from being thrown when attempting to set a property that has been disposed.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [x] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated.~~
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] ~~Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).~~
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

