### PR TITLE
fix: Prevent exceptions from being thrown when detaching a disposed child

### DIFF
--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseChildrenTests.cs
@@ -58,6 +58,20 @@ namespace Chinook.DynamicMvvm.Tests.ViewModel
 		}
 
 		[Fact]
+		public void It_Doesnt_Throw_When_Calling_Detach_With_A_Disposed_Child()
+		{
+			var parentViewModel = new ViewModelBase();
+			var childViewModel = new ViewModelBase();
+
+			parentViewModel.AttachChild(childViewModel);
+
+			childViewModel.Dispose();
+			parentViewModel.DetachChild(childViewModel);
+
+			parentViewModel.GetChildren().Should().NotContain(childViewModel);
+		}
+
+		[Fact]
 		public void It_Gets_Child_On_Attach()
 		{
 			var parentViewModel = new ViewModelBase();


### PR DESCRIPTION

GitHub Issue: #87
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- `DetachChild` throws exceptions when called with a disposed child.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- `DetachChild` doesn't throw exceptions when called with a disposed child.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

