### PR TITLE
Benchmarks and LoggerMessage optimizations

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,8 @@
 # Breaking Changes
 
+## 1.3.0
+- The NuGet reference to `Microsoft.Extensions.Logging.Abstractions` now requires version 6.0.0 and up.
+
 ## 0.11.0
 - `DecoratorCommandStrategy` not longer exists. Use `DelegatingCommandStrategy` instead.
 

--- a/DynamicMvvm.sln
+++ b/DynamicMvvm.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamicMvvm.Uno.WinUI", "sr
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "DynamicMvvm.Shared", "src\DynamicMvvm.Shared\DynamicMvvm.Shared.shproj", "{8BCF881B-035B-4572-A0B5-27C379DEBEE8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicMvvm.Benchmarks", "src\DynamicMvvm.Benchmarks\DynamicMvvm.Benchmarks.csproj", "{8494F013-2C55-4B51-98E1-6006807C2D4C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Android = Debug|Android
@@ -289,6 +291,38 @@ Global
 		{1E13272A-4270-4F68-88B7-A54375866640}.Release|x64.Build.0 = Release|x64
 		{1E13272A-4270-4F68-88B7-A54375866640}.Release|x86.ActiveCfg = Release|x86
 		{1E13272A-4270-4F68-88B7-A54375866640}.Release|x86.Build.0 = Release|x86
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Android.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Android.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|iOS.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|iOS.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|NuGet.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|NuGet.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Simulator.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|Simulator.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|UAP.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|UAP.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|x64.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Debug|x86.Build.0 = Debug|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Android.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Android.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|iOS.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|iOS.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|NuGet.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|NuGet.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Simulator.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|Simulator.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|UAP.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|UAP.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|x64.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|x64.Build.0 = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|x86.ActiveCfg = Release|Any CPU
+		{8494F013-2C55-4B51-98E1-6006807C2D4C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/DynamicMvvm.Abstractions/DynamicMvvm.Abstractions.csproj
+++ b/src/DynamicMvvm.Abstractions/DynamicMvvm.Abstractions.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<LangVersion>10</LangVersion>
 		<RootNamespace>Chinook.DynamicMvvm</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
@@ -30,7 +31,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DynamicMvvm.Abstractions/LoggerMessages.Abstractions.cs
+++ b/src/DynamicMvvm.Abstractions/LoggerMessages.Abstractions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm
+{
+	internal static partial class LoggerMessagesAbstractions
+	{
+		[LoggerMessage(101, LogLevel.Warning, "Resolving property '{ViewModelTypeName}.{PropertyName}' using reflection on '{ViewModelName}'.")]
+		public static partial void LogViewModelResolvingPropertyUsingReflection(this ILogger logger, string viewModelTypeName, string propertyName, string viewModelName);
+	}
+}

--- a/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
+++ b/src/DynamicMvvm.Abstractions/ViewModel/IViewModel.Extensions.Properties.cs
@@ -248,7 +248,7 @@ namespace Chinook.DynamicMvvm
 
 			if (!viewModel.TryGetDisposable<IDynamicProperty>(name, out var property))
 			{
-				typeof(IViewModel).Log().LogWarning($"Resolving property '{viewModel.GetType().Name}.{name}' using reflection on '{viewModel.Name}'.");
+				typeof(IViewModel).Log().LogViewModelResolvingPropertyUsingReflection(viewModel.GetType().Name, name, viewModel.Name);
 
 				// This is a rare case where the property was resolved before being created.
 				// We simply resolve it manually on the type.

--- a/src/DynamicMvvm.Benchmarks/Benchmark.cs
+++ b/src/DynamicMvvm.Benchmarks/Benchmark.cs
@@ -30,6 +30,12 @@ public class Benchmark
 		var vm = new ViewModel(_serviceProvider);
 	}
 
+	[Benchmark]
+	public void CreateViewModel_WithExplicitName()
+	{
+		var vm = new ViewModel("ViewModel", _serviceProvider);
+	}
+
 	[IterationSetup(Targets = new[]
 	{
 		nameof(ReadProperty_Unresolved),
@@ -40,7 +46,7 @@ public class Benchmark
 	})]
 	public void SetupViewModel()
 	{
-		_viewModel1 = new ViewModel(_serviceProvider);
+		_viewModel1 = new ViewModel("ViewModel", _serviceProvider);
 	}
 
 	[IterationSetup(Targets = new[]
@@ -51,7 +57,7 @@ public class Benchmark
 	})]
 	public void SetupViewModelWithListener()
 	{
-		_viewModel2 = new ViewModel(_serviceProvider);
+		_viewModel2 = new ViewModel("ViewModel", _serviceProvider);
 		_viewModel2.PropertyChanged += (s, e) => { };
 	}
 
@@ -101,5 +107,5 @@ public class Benchmark
 	public void DisposeViewModel_WithListener()
 	{
 		_viewModel2!.Dispose();
-	}	
+	}
 }

--- a/src/DynamicMvvm.Benchmarks/Benchmark.cs
+++ b/src/DynamicMvvm.Benchmarks/Benchmark.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Chinook.DynamicMvvm;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DynamicMvvm.Benchmarks;
+
+[MemoryDiagnoser]
+public class Benchmark
+{
+	private readonly IServiceProvider _serviceProvider = new HostBuilder()
+		.ConfigureServices(serviceCollection => serviceCollection
+			.AddSingleton<IDynamicCommandBuilderFactory, DynamicCommandBuilderFactory>()
+			.AddSingleton<IDynamicPropertyFactory, DynamicPropertyFactory>()
+		)
+		.Build()
+		.Services;
+
+	private ViewModel? _viewModel1;
+	private ViewModel? _viewModel2;
+
+	[Benchmark]
+	public void CreateViewModel()
+	{
+		var vm = new ViewModel(_serviceProvider);
+	}
+
+	[IterationSetup(Targets = new[]
+	{
+		nameof(ReadProperty_Unresolved),
+		nameof(ReadProperty_Resolved),
+		nameof(SetProperty_Unresolved),
+		nameof(SetProperty_Resolved),
+		nameof(DisposeViewModel),
+	})]
+	public void SetupViewModel()
+	{
+		_viewModel1 = new ViewModel(_serviceProvider);
+	}
+
+	[IterationSetup(Targets = new[]
+	{
+		nameof(SetProperty_Unresolved_WithListener),
+		nameof(SetProperty_Resolved_WithListener),
+		nameof(DisposeViewModel_WithListener),
+	})]
+	public void SetupViewModelWithListener()
+	{
+		_viewModel2 = new ViewModel(_serviceProvider);
+		_viewModel2.PropertyChanged += (s, e) => { };
+	}
+
+	[Benchmark]
+	public void ReadProperty_Unresolved()
+	{
+		var value = _viewModel1!.Number;
+	}
+
+	[Benchmark]
+	public void ReadProperty_Resolved()
+	{
+		var value = _viewModel1!.NumberResolved;
+	}
+
+	[Benchmark]
+	public void SetProperty_Unresolved()
+	{
+		_viewModel1!.Number = 1;
+	}
+
+	[Benchmark]
+	public void SetProperty_Resolved()
+	{
+		_viewModel1!.NumberResolved = 1;
+	}
+
+	[Benchmark]
+	public void DisposeViewModel()
+	{
+		_viewModel1!.Dispose();
+	}
+
+	[Benchmark]
+	public void SetProperty_Unresolved_WithListener()
+	{
+		_viewModel2!.Number = 1;
+	}
+
+	[Benchmark]
+	public void SetProperty_Resolved_WithListener()
+	{
+		_viewModel2!.NumberResolved = 1;
+	}
+
+	[Benchmark]
+	public void DisposeViewModel_WithListener()
+	{
+		_viewModel2!.Dispose();
+	}	
+}

--- a/src/DynamicMvvm.Benchmarks/DynamicMvvm.Benchmarks.csproj
+++ b/src/DynamicMvvm.Benchmarks/DynamicMvvm.Benchmarks.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DynamicMvvm.CollectionTracking\DynamicMvvm.CollectionTracking.csproj" />
+    <ProjectReference Include="..\DynamicMvvm.FluentValidation\DynamicMvvm.FluentValidation.csproj" />
+    <ProjectReference Include="..\DynamicMvvm.Reactive\DynamicMvvm.Reactive.csproj" />
+    <ProjectReference Include="..\DynamicMvvm\DynamicMvvm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DynamicMvvm.Benchmarks/DynamicMvvm.Benchmarks.csproj
+++ b/src/DynamicMvvm.Benchmarks/DynamicMvvm.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DynamicMvvm.Benchmarks/Program.cs
+++ b/src/DynamicMvvm.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using DynamicMvvm.Benchmarks;
+
+BenchmarkRunner.Run<Benchmark>();

--- a/src/DynamicMvvm.Benchmarks/Program.cs
+++ b/src/DynamicMvvm.Benchmarks/Program.cs
@@ -1,4 +1,22 @@
 ﻿using BenchmarkDotNet.Running;
 using DynamicMvvm.Benchmarks;
+using Chinook.DynamicMvvm;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 BenchmarkRunner.Run<Benchmark>();
+
+// The following section is to profile manually using Visual Studio's debugger.
+
+//var serviceProvider = new HostBuilder()
+//	.ConfigureServices(serviceCollection => serviceCollection
+//		.AddSingleton<IDynamicCommandBuilderFactory, DynamicCommandBuilderFactory>()
+//		.AddSingleton<IDynamicPropertyFactory, DynamicPropertyFactory>()
+//	)
+//	.Build()
+//	.Services;
+
+//var vm1 = new ViewModel("ViewModel", serviceProvider);
+//var vm2 = new ViewModel("ViewModel", serviceProvider);
+
+//Console.Read();

--- a/src/DynamicMvvm.Benchmarks/ViewModel.cs
+++ b/src/DynamicMvvm.Benchmarks/ViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chinook.DynamicMvvm;
+
+namespace DynamicMvvm.Benchmarks;
+
+public class ViewModel : ViewModelBase
+{
+	public ViewModel(IServiceProvider serviceProvider)
+		: base(serviceProvider: serviceProvider)
+	{
+		var value = NumberResolved;
+	}
+
+	public int Number
+	{
+		get => this.Get(initialValue: 42);
+		set => this.Set(value);
+	}
+
+	public int NumberResolved
+	{
+		get => this.Get(initialValue: 42);
+		set => this.Set(value);
+	}
+}

--- a/src/DynamicMvvm.Benchmarks/ViewModel.cs
+++ b/src/DynamicMvvm.Benchmarks/ViewModel.cs
@@ -9,10 +9,15 @@ namespace DynamicMvvm.Benchmarks;
 
 public class ViewModel : ViewModelBase
 {
-	public ViewModel(IServiceProvider serviceProvider)
-		: base(serviceProvider: serviceProvider)
+	public ViewModel(string? name, IServiceProvider serviceProvider)
+		: base(name, serviceProvider)
 	{
 		var value = NumberResolved;
+	}
+
+	public ViewModel(IServiceProvider serviceProvider)
+		: this(name: default, serviceProvider: serviceProvider)
+	{
 	}
 
 	public int Number

--- a/src/DynamicMvvm.FluentValidation/DynamicMvvm.FluentValidation.csproj
+++ b/src/DynamicMvvm.FluentValidation/DynamicMvvm.FluentValidation.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<LangVersion>10</LangVersion>
 		<RootNamespace>Chinook.DynamicMvvm</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>

--- a/src/DynamicMvvm.FluentValidation/IViewModel.Extensions.Validation.cs
+++ b/src/DynamicMvvm.FluentValidation/IViewModel.Extensions.Validation.cs
@@ -168,7 +168,7 @@ namespace Chinook.DynamicMvvm
 					}
 					catch (Exception e)
 					{
-						this.Log().LogError(e, $"Validation failed for property '{property.Name}'.");
+						this.Log().LogValidationFailed(property.Name, e);
 					}
 				});
 			}

--- a/src/DynamicMvvm.FluentValidation/LoggerMessages.FluentValidation.cs
+++ b/src/DynamicMvvm.FluentValidation/LoggerMessages.FluentValidation.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm
+{
+	internal static partial class LoggerMessages
+	{
+		[LoggerMessage(201, LogLevel.Error, "Validation failed for property '{PropertyName}'.")]
+		public static partial void LogValidationFailed(this ILogger logger, string propertyName, Exception exception);
+	}
+}

--- a/src/DynamicMvvm.Reactive/Deactivation/DeactivatableObservable.cs
+++ b/src/DynamicMvvm.Reactive/Deactivation/DeactivatableObservable.cs
@@ -61,7 +61,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 
 			IsDeactivated = true;
 
-			typeof(IDeactivatable).Log().LogDebug($"Deactivated observable of type '{typeof(T).Name}'.");
+			typeof(IDeactivatable).Log().LogDeactivatedObservable(typeof(T).Name);
 		}
 
 		/// <inheritdoc/>
@@ -79,7 +79,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 				_subscription = _source.Subscribe(_observer);
 			}
 
-			typeof(IDeactivatable).Log().LogDebug($"Reactivated observable of type '{typeof(T).Name}'.");
+			typeof(IDeactivatable).Log().LogReactivatedObservable(typeof(T).Name);
 		}
 
 		/// <inheritdoc/>

--- a/src/DynamicMvvm.Reactive/DynamicMvvm.Reactive.csproj
+++ b/src/DynamicMvvm.Reactive/DynamicMvvm.Reactive.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<LangVersion>10</LangVersion>
 		<RootNamespace>Chinook.DynamicMvvm</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
@@ -29,8 +30,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
 		<PackageReference Include="System.Reactive" Version="4.4.1" />
 	</ItemGroup>

--- a/src/DynamicMvvm.Reactive/LoggerMessages.Reactive.cs
+++ b/src/DynamicMvvm.Reactive/LoggerMessages.Reactive.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm
+{
+	internal static partial class LoggerMessagesReactive
+	{
+		[LoggerMessage(301, LogLevel.Debug, "Deactivated observable of type '{TypeName}'.")]
+		public static partial void LogDeactivatedObservable(this ILogger logger, string typeName);
+
+		[LoggerMessage(302, LogLevel.Debug, "Reactivated observable of type '{TypeName}'.")]
+		public static partial void LogReactivatedObservable(this ILogger logger, string typeName);
+
+	}
+}

--- a/src/DynamicMvvm.Uno.WinUI/Dispatchers/BatchingDispatcherQueueDispatcher.cs
+++ b/src/DynamicMvvm.Uno.WinUI/Dispatchers/BatchingDispatcherQueueDispatcher.cs
@@ -56,13 +56,13 @@ namespace Chinook.DynamicMvvm
 		{
 			if (ct.IsCancellationRequested)
 			{
-				this.Log().LogDebug($"Cancelled 'ExecuteOnDispatcher' because of the cancellation token.");
+				this.Log().LogCancelledExecuteOnDispatcherBecauseOfCancellationToken();
 				return;
 			}
 
 			if (GetHasDispatcherAccess())
 			{
-				this.Log().LogDebug($"Executed action immediately because already on dispatcher.");
+				this.Log().LogExecutedActionImmediatelyBecauseAlreadyOnDispatcher();
 				action();
 				return;
 			}
@@ -94,7 +94,8 @@ namespace Chinook.DynamicMvvm
 					{
 						if (request.CT.IsCancellationRequested)
 						{
-							this.Log().LogDebug($"Cancelled 'ExecuteOnDispatcher' because of the cancellation token.");
+							this.Log().LogCancelledExecuteOnDispatcherBecauseOfCancellationToken();
+							
 							continue;
 						}
 
@@ -102,12 +103,12 @@ namespace Chinook.DynamicMvvm
 					}
 					catch (Exception e)
 					{
-						this.Log().LogError(e, "Failed 'ExecuteOnDispatcher'.");
+						this.Log().LogFailedExecuteOnDispatcher(e);
 					}
 				}
 			});
 
-			this.Log().LogDebug($"Batched {requests.Length} dispatcher requests.");
+			this.Log().LogBatchedDispatcherRequests(requests.Length);
 		}
 
 		private class Request

--- a/src/DynamicMvvm.Uno.WinUI/Dispatchers/DispatcherQueueDispatcher.cs
+++ b/src/DynamicMvvm.Uno.WinUI/Dispatchers/DispatcherQueueDispatcher.cs
@@ -51,7 +51,7 @@ namespace Chinook.DynamicMvvm
 		{
 			if (ct.IsCancellationRequested)
 			{
-				this.Log().LogDebug($"Cancelled 'ExecuteOnDispatcher' because of the cancellation token.");
+				this.Log().LogCancelledExecuteOnDispatcherBecauseOfCancellationToken();
 				return;
 			}
 
@@ -61,7 +61,7 @@ namespace Chinook.DynamicMvvm
 				{
 					if (ct.IsCancellationRequested)
 					{
-						this.Log().LogDebug($"Cancelled 'ExecuteOnDispatcher' because of the cancellation token.");
+						this.Log().LogCancelledExecuteOnDispatcherBecauseOfCancellationToken();
 						return;
 					}
 
@@ -69,7 +69,7 @@ namespace Chinook.DynamicMvvm
 				}
 				catch (Exception e)
 				{
-					this.Log().LogError(e, "Failed 'ExecuteOnDispatcher'.");
+					this.Log().LogFailedExecuteOnDispatcher(e);
 				}
 			});
 		}

--- a/src/DynamicMvvm.Uno.WinUI/LoggerMessages.Uno.WinUI.cs
+++ b/src/DynamicMvvm.Uno.WinUI/LoggerMessages.Uno.WinUI.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm
+{
+	internal static partial class LoggerMessagesUnoWinUI
+	{
+		[LoggerMessage(401, LogLevel.Debug, "Cancelled 'ExecuteOnDispatcher' because of the cancellation token.")]
+		public static partial void LogCancelledExecuteOnDispatcherBecauseOfCancellationToken(this ILogger logger);
+
+		[LoggerMessage(402, LogLevel.Debug, "Executed action immediately because already on dispatcher.")]
+		public static partial void LogExecutedActionImmediatelyBecauseAlreadyOnDispatcher(this ILogger logger);
+
+		[LoggerMessage(403, LogLevel.Debug, "Batched {RequestCount} dispatcher requests.")]
+		public static partial void LogBatchedDispatcherRequests(this ILogger logger, int requestCount);
+
+		[LoggerMessage(404, LogLevel.Error, "Failed 'ExecuteOnDispatcher'.")]
+		public static partial void LogFailedExecuteOnDispatcher(this ILogger logger, Exception exception);
+	}
+}

--- a/src/DynamicMvvm/Command/DynamicCommand.cs
+++ b/src/DynamicMvvm/Command/DynamicCommand.cs
@@ -75,7 +75,7 @@ namespace Chinook.DynamicMvvm
 				if (_isDisposed)
 				{
 					// Note that we don't throw an ObjectDisposedException here because we're likely on a UI thread.
-					this.Log().LogError("Failed to execute command '{Name}' because it's disposed.", Name);
+					this.Log().LogCommandFailedBecauseDisposed(Name);
 					return;
 				}
 
@@ -99,7 +99,7 @@ namespace Chinook.DynamicMvvm
 			{
 				// This will run on a UI thread, so we want to make sure
 				// this task doesn't throw otherwise it could lead to a crash.
-				this.Log().LogError(e, $"Command execution of '{Name}' failed. Consider using {nameof(ErrorHandlerCommandStrategy)}.");
+				this.Log().LogCommandFailedConsiderUsingErrorHandlerCommandStrategy(Name, e);
 			}
 		}
 

--- a/src/DynamicMvvm/Command/Strategies/LoggerCommandStrategy.cs
+++ b/src/DynamicMvvm/Command/Strategies/LoggerCommandStrategy.cs
@@ -40,15 +40,15 @@ namespace Chinook.DynamicMvvm
 		{
 			try
 			{
-				_logger.LogDebug($"Executing command '{command.Name}'.");
+				_logger.LogCommandExecuting(command.Name);
 
 				await base.Execute(ct, parameter, command);
 
-				_logger.LogInformation($"Executed command '{command.Name}'.");
+				_logger.LogCommandExecuted(command.Name);
 			}
 			catch (Exception e)
 			{
-				_logger.LogError(e, $"Failed to execute command '{command.Name}'.");
+				_logger.LogCommandFailed(command.Name, e);
 
 				throw;
 			}

--- a/src/DynamicMvvm/Deactivation/DeactivatableDynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Deactivation/DeactivatableDynamicPropertyFromObservable.cs
@@ -72,7 +72,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 
 			IsDeactivated = true;
 
-			typeof(IDeactivatable).Log().LogDebug($"Deactivated observable source of property '{Name}'.");
+			typeof(IDeactivatable).Log().LogDeactivatedObservableSource(Name);
 		}
 
 		/// <inheritdoc/>
@@ -87,7 +87,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 
 			_subscription = _source.Subscribe(_propertyObserver);
 
-			typeof(IDeactivatable).Log().LogDebug($"Reactivated observable source of property '{Name}'.");
+			typeof(IDeactivatable).Log().LogReactivatedObservableSource(Name);
 		}
 	}
 }

--- a/src/DynamicMvvm/Deactivation/DeactivatableViewModelBase.cs
+++ b/src/DynamicMvvm/Deactivation/DeactivatableViewModelBase.cs
@@ -84,7 +84,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 				child.Deactivate();
 			}
 
-			typeof(IDeactivatable).Log().LogDebug($"Deactivated ViewModel '{Name}'.");
+			typeof(IDeactivatable).Log().LogDeactivatedViewModel(Name);
 		}
 
 		/// <summary>
@@ -116,7 +116,7 @@ namespace Chinook.DynamicMvvm.Deactivation
 				child.Reactivate();
 			}
 
-			typeof(IDeactivatable).Log().LogDebug($"Reactivated ViewModel '{Name}' and raised {toRaise.Length} property changes.");
+			typeof(IDeactivatable).Log().LogReactivatedViewModel(Name, toRaise.Length);
 		}
 	}
 }

--- a/src/DynamicMvvm/DynamicMvvm.csproj
+++ b/src/DynamicMvvm/DynamicMvvm.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<LangVersion>10</LangVersion>
 		<RootNamespace>Chinook.DynamicMvvm</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
@@ -29,8 +30,6 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
 	</ItemGroup>
 

--- a/src/DynamicMvvm/LoggerMessages.cs
+++ b/src/DynamicMvvm/LoggerMessages.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Chinook.DynamicMvvm
+{
+	internal static partial class LoggerMessages
+	{
+		[LoggerMessage(1, LogLevel.Information, "ViewModel '{ViewModelName}' created.")]
+		public static partial void LogViewModelCreated(this ILogger logger, string viewModelName);
+
+		[LoggerMessage(2, LogLevel.Information, "ViewModel '{ViewModelName}' disposed.")]
+		public static partial void LogViewModelDisposed(this ILogger logger, string viewModelName);
+
+		[LoggerMessage(3, LogLevel.Debug, "Disposing ViewModel '{ViewModelName}'.")]
+		public static partial void LogViewModelDisposing(this ILogger logger, string viewModelName);
+
+		[LoggerMessage(4, LogLevel.Error, "Failed to dispose disposable '{DisposableKey}' of ViewModel '{ViewModelName}'.")]
+		public static partial void LogViewModelFailedToDisposeDisposable(this ILogger logger, string disposableKey, string viewModelName, Exception exception);
+
+		[LoggerMessage(5, LogLevel.Information, "ViewModel '{ViewModelName}' destroyed.")]
+		public static partial void LogViewModelDestroyed(this ILogger logger, string viewModelName);
+
+		[LoggerMessage(6, LogLevel.Debug, "Skipped '{MethodName}' on ViewModel '{ViewModelName}' because it's disposing.")]
+		public static partial void LogViewModelSkippedMethodBecauseDisposing(this ILogger logger, string methodName, string viewModelName);
+
+		[LoggerMessage(7, LogLevel.Debug, "Skipped '{MethodName}' for key '{DisposableKey}' on ViewModel '{ViewModelName}' because it's disposing.")]
+		public static partial void LogViewModelSkippedMethodBecauseDisposing_DisposableKey(this ILogger logger, string methodName, string disposableKey, string viewModelName);
+
+		[LoggerMessage(8, LogLevel.Debug, "Skipped '{MethodName}' for '{TypeName}.{PropertyName}' on ViewModel '{ViewModelName}' because it's disposing.")]
+		public static partial void LogViewModelSkippedMethodBecauseDisposing_PropertyName(this ILogger logger, string methodName, string typeName, string propertyName, string viewModelName);
+
+		[LoggerMessage(9, LogLevel.Debug, "Skipped '{MethodName}' for '{TypeName}.{PropertyName}' on ViewModel '{ViewModelName}' because it's disposed.")]
+		public static partial void LogViewModelSkippedMethodBecauseDisposed_PropertyName(this ILogger logger, string methodName, string typeName, string propertyName, string viewModelName);
+
+		[LoggerMessage(10, LogLevel.Debug, "Raised property changed for '{PropertyName}' from ViewModel '{ViewModelName}'.")]
+		public static partial void LogViewModelRaisedPropertyChanged(this ILogger logger, string propertyName, string viewModelName);
+				
+		[LoggerMessage(11, LogLevel.Error, "Failed to raise PropertyChanged. Your IVewModel.Dispatcher is null. Make sure you set it. Make sure you link child viewmodels to their parent by using one of the following IViewModel extension method: AttachChild, GetChild, AttachOrReplaceChild.")]
+		public static partial void LogViewModelFailedToRaisePropertyChangedWhenDispatcherIsNull(this ILogger logger, Exception exception);
+
+		[LoggerMessage(20, LogLevel.Debug, "Executing command '{CommandName}'.")]
+		public static partial void LogCommandExecuting(this ILogger logger, string commandName);
+
+		[LoggerMessage(21, LogLevel.Information, "Executed command '{CommandName}'.")]
+		public static partial void LogCommandExecuted(this ILogger logger, string commandName);
+
+		[LoggerMessage(22, LogLevel.Error, "Failed to execute command '{CommandName}'.")]
+		public static partial void LogCommandFailed(this ILogger logger, string commandName, Exception exception);
+
+		[LoggerMessage(23, LogLevel.Error, "Failed to execute command '{CommandName}'. Consider using ErrorHandlerCommandStrategy.")]
+		public static partial void LogCommandFailedConsiderUsingErrorHandlerCommandStrategy(this ILogger logger, string commandName, Exception exception);
+
+		[LoggerMessage(24, LogLevel.Error, "Failed to execute command '{CommandName}' because it's disposed.")]
+		public static partial void LogCommandFailedBecauseDisposed(this ILogger logger, string commandName);
+
+		[LoggerMessage(30, LogLevel.Error, "Source observable subscription failed for property '{PropertyName}'. The property will no longer be updated by the observable.")]
+		public static partial void LogDynamicPropertySourceObservableSubscriptionFailed(this ILogger logger, string propertyName, Exception exception);
+
+		[LoggerMessage(31, LogLevel.Error, "Source task failed for property '{PropertyName}'.")]
+		public static partial void LogDynamicPropertySourceTaskFailed(this ILogger logger, string propertyName, Exception exception);
+
+		[LoggerMessage(40, LogLevel.Debug, "Deactivated observable source of property '{PropertyName}'.")]
+		public static partial void LogDeactivatedObservableSource(this ILogger logger, string propertyName);
+
+		[LoggerMessage(41, LogLevel.Debug, "Reactivated observable source of property '{PropertyName}'.")]
+		public static partial void LogReactivatedObservableSource(this ILogger logger, string propertyName);
+
+		[LoggerMessage(42, LogLevel.Debug, "Deactivated ViewModel '{ViewModelName}'.")]
+		public static partial void LogDeactivatedViewModel(this ILogger logger, string viewModelName);
+
+		[LoggerMessage(43, LogLevel.Debug, "Reactivated ViewModel '{ViewModelName}' and raised {PropertyChangedCount} property changes.")]
+		public static partial void LogReactivatedViewModel(this ILogger logger, string viewModelName, int propertyChangedCount);
+
+	}
+}

--- a/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
@@ -88,7 +88,7 @@ namespace Chinook.DynamicMvvm
 
 			public void OnError(Exception e)
 			{
-				this.Log().LogError(e, $"Source observable subscription failed for property '{_owner.Name}'. The property will no longer be updated by the observable.");
+				this.Log().LogDynamicPropertySourceObservableSubscriptionFailed(_owner.Name, e);
 			}
 
 			public void OnNext(T value)

--- a/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
@@ -68,7 +68,7 @@ namespace Chinook.DynamicMvvm
 			}
 			catch (Exception e)
 			{
-				this.Log().LogError(e, $"Source task failed for property '{Name}'.");
+				this.Log().LogDynamicPropertySourceTaskFailed(Name, e);
 			}
 			//});
 		}

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
@@ -68,7 +68,7 @@ namespace Chinook.DynamicMvvm.Implementations
 			}
 			catch (Exception e)
 			{
-				this.Log().LogError(e, $"Source task failed for property '{Name}'.");
+				this.Log().LogDynamicPropertySourceTaskFailed(Name, e);
 			}
 		}
 

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Dispatcher.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Dispatcher.cs
@@ -31,7 +31,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped invocation of '{nameof(DispatcherChanged)}' on ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing(nameof(DispatcherChanged), Name);
 				return;
 			}
 

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -43,7 +43,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug("Skipped '{MethodName}' for key '{DisposableKey}' on ViewModel '{ViewModelName}' because it's disposing.", nameof(AddDisposable), key, Name);
+				_logger.LogViewModelSkippedMethodBecauseDisposing_DisposableKey(nameof(AddDisposable), key, Name);
 				return;
 			}
 
@@ -92,7 +92,7 @@ namespace Chinook.DynamicMvvm
 
 			if (isDisposing)
 			{
-				_logger.LogDebug($"Disposing ViewModel '{Name}'.");
+				_logger.LogViewModelDisposing(Name);
 
 				_isDisposing = true;
 				_cts.Cancel();
@@ -105,7 +105,7 @@ namespace Chinook.DynamicMvvm
 					}
 					catch (Exception e)
 					{
-						_logger.LogError(e, $"Failed to dispose disposable '{pair.Key}' of ViewModel '{Name}'.");
+						_logger.LogViewModelFailedToDisposeDisposable(pair.Key, Name, e);
 					}
 				}
 
@@ -121,7 +121,7 @@ namespace Chinook.DynamicMvvm
 				_diagnostics.Write("Disposed", Name);
 			}
 
-			_logger.LogInformation($"Disposed ViewModel '{Name}'.");
+			_logger.LogViewModelDisposed(Name);
 		}
 
 		/// <inheritdoc />
@@ -147,7 +147,7 @@ namespace Chinook.DynamicMvvm
 				_diagnostics.Write("Destroyed", Name);
 			}
 
-			_logger.LogInformation($"ViewModel '{Name}' destroyed.");
+			_logger.LogViewModelDestroyed(Name);
 		}
 	}
 }

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
@@ -45,7 +45,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped '{nameof(SetErrors)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing_PropertyName(nameof(SetErrors), GetType().Name, propertyName, Name);
 				return;
 			}
 
@@ -61,7 +61,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped '{nameof(SetErrors)}' for ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing(nameof(SetErrors), Name);
 				return;
 			}
 
@@ -77,7 +77,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped '{nameof(ClearErrors)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing_PropertyName(nameof(ClearErrors), GetType().Name, propertyName, Name);
 				return;
 			}
 

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -17,7 +17,7 @@ namespace Chinook.DynamicMvvm
 
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped '{nameof(RaisePropertyChanged)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing_PropertyName(nameof(RaisePropertyChanged), GetType().Name, propertyName, Name);
 				return;
 			}
 
@@ -40,13 +40,13 @@ namespace Chinook.DynamicMvvm
 		{
 			if (_isDisposing)
 			{
-				_logger.LogDebug($"Skipped '{nameof(RaisePropertyChangedInner)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposing.");
+				_logger.LogViewModelSkippedMethodBecauseDisposing_PropertyName(nameof(RaisePropertyChangedInner), GetType().Name, propertyName, Name);
 				return;
 			}
 
 			if (_isDisposed)
 			{
-				_logger.LogDebug($"Skipped '{nameof(RaisePropertyChangedInner)}' for '{GetType().Name}.{propertyName}' on ViewModel '{Name}' because it's disposed.");
+				_logger.LogViewModelSkippedMethodBecauseDisposed_PropertyName(nameof(RaisePropertyChangedInner), GetType().Name, propertyName, Name);
 				return;
 			}
 
@@ -57,11 +57,11 @@ namespace Chinook.DynamicMvvm
 			catch (Exception exception) when (Dispatcher is null)
 			{
 				// Give some details and tips on how to fix the issue.
-				_logger.LogError(exception, "Failed to raise PropertyChanged. Your IVewModel.Dispatcher is null. Make sure you set it. Make sure you link child viewmodels to their parent by using one of the following IViewModel extension method: AttachChild, GetChild, AttachOrReplaceChild.");
+				_logger.LogViewModelFailedToRaisePropertyChangedWhenDispatcherIsNull(exception);
 				throw;
 			}
 
-			_logger.LogDebug($"Raised property changed for '{propertyName}' from ViewModel '{Name}'.");
+			_logger.LogViewModelRaisedPropertyChanged(propertyName, Name);
 		}
 	}
 }

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.cs
@@ -33,7 +33,7 @@ namespace Chinook.DynamicMvvm
 				_diagnostics.Write("Created", Name);
 			}
 
-			_logger.LogInformation($"ViewModel '{Name}' created.");
+			_logger.LogViewModelCreated(Name);
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

- Add a benchmark project to measure the performance of some common scenarios.
- All logs now use `LoggerMessage` to reduce memory allocations and speed-up the execution when the log levels are disabled.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

| Method                              | Mean      | Allocated |
|------------------------------------ |----------:|----------:|
| CreateViewModel                     |  2.278 μs |    2023 B |
| CreateViewModel_WithExplicitName    |           |           |
| ReadProperty_Unresolved             |  2.754 μs |    1032 B |
| ReadProperty_Resolved               |  1.409 μs |     896 B |
| SetProperty_Unresolved              | 19.147 μs |    3016 B |
| SetProperty_Resolved                |  1.957 μs |     832 B |
| DisposeViewModel                    |  2.954 μs |     776 B |
| SetProperty_Unresolved_WithListener | 21.014 μs |    3256 B |
| SetProperty_Resolved_WithListener   |  3.031 μs |    1088 B |
| DisposeViewModel_WithListener       |  2.932 μs |     776 B |

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

| Method                              | Mean      | Allocated |
|------------------------------------ |----------:|----------:|
| CreateViewModel                     |  2.057 μs |    1760 B |
| CreateViewModel_WithExplicitName    |  2.077 μs |    1760 B |
| ReadProperty_Unresolved             |  2.866 μs |     856 B |
| ReadProperty_Resolved               |  1.423 μs |     720 B |
| SetProperty_Unresolved              | 22.519 μs |    2592 B |
| SetProperty_Resolved                |  1.837 μs |     656 B |
| DisposeViewModel                    |  1.340 μs |     600 B |
| SetProperty_Unresolved_WithListener | 21.484 μs |    2616 B |
| SetProperty_Resolved_WithListener   |  2.303 μs |     680 B |
| DisposeViewModel_WithListener       |  1.301 μs |     600 B |

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.
  - The version bump is minor even though this is a patch because it contains a minor breaking change (bump of nuget dependency versions) .

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

