### PR TITLE
feat: Add overload of GetFromDeactivatableObservable that uses a Func

### DIFF
--- a/src/DynamicMvvm/Deactivation/IDeactivatableViewModel.Extensions.cs
+++ b/src/DynamicMvvm/Deactivation/IDeactivatableViewModel.Extensions.cs
@@ -25,5 +25,21 @@ namespace Chinook.DynamicMvvm
 		{
 			return viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => new DeactivatableDynamicPropertyFromObservable<T>(name, source, viewModel, initialValue)));
 		}
+
+		/// <summary>
+		/// Gets or creates a <see cref="IDynamicProperty"/> attached to this <see cref="IViewModel"/>.<br/>
+		/// The underlying <see cref="IDynamicProperty"/> implements <see cref="IDeactivatable"/> so the observation can be deactivated.
+		/// This overload uses a <see cref="Func{TResult}"/> to avoid evaluating the observable sequence more than once (which can avoid memory allocations).
+		/// </summary>
+		/// <typeparam name="T">The property type.</typeparam>
+		/// <param name="viewModel">The <see cref="IViewModel"/> owning the property.</param>
+		/// <param name="sourceProvider">The provider of the observable of values that feeds the property.</param>
+		/// <param name="initialValue">The property's initial value.</param>
+		/// <param name="name">The property's name.</param>
+		/// <returns>The property's value.</returns>
+		public static T GetFromDeactivatableObservable<T>(this IDeactivatableViewModel viewModel, Func<IObservable<T>> sourceProvider, T initialValue = default, [CallerMemberName] string name = null)
+		{
+			return viewModel.Get<T>(viewModel.GetOrCreateDynamicProperty(name, n => new DeactivatableDynamicPropertyFromObservable<T>(name, sourceProvider(), viewModel, initialValue)));
+		}
 	}
 }


### PR DESCRIPTION

GitHub Issue: solves #89
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

- Add overload of `GetFromDeactivatableObservable` that uses a `Func<IObservable<T>>` to allow lazy evaluation of the observable sequence to allow fewer memory allocations.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [x] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

