### PR TITLE
fix: DynamicProperties no longer throw ObjectDisposedExceptions

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,7 +1,18 @@
 # Breaking Changes
 
+## 1.4.1
+- Dynamic properties no longer throw an `ObjectDisposedException` when we set their `Value` while they're disposed.
+  - We've discovered that this safeguard is not needed and was causing unjustified issues when using dynamic properties in a multi-threaded environment. This is especially true with the _DynamicPropertyFromObservable_ variant, which can easily be disposed from a different thread than the one the observable source uses.
+  - This change renders obsolete the `throwOnDisposed` parameter used in several constructors of `IDynamicProperty` and `IDynamicPropertyFactory` implementations.
+    Those overloads are still present in the library, but they are marked as obsolete and will be removed in a future version.
+  - You can still observe the events where a dynamic property is set while it's disposed by using logs. The event id is 32, the log level is `Debug`, and the message template is `"Skipped value setter on the property '{PropertyName}' because it's disposed."`
+
+This breaking changes doesn't change the API definition.
+
 ## 1.3.0
 - The NuGet reference to `Microsoft.Extensions.Logging.Abstractions` now requires version 6.0.0 and up.
+
+This breaking change doesn't change the API definition.
 
 ## 0.11.0
 - `DecoratorCommandStrategy` not longer exists. Use `DelegatingCommandStrategy` instead.

--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyFactoryTests.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyFactoryTests.cs
@@ -80,50 +80,5 @@ namespace Chinook.DynamicMvvm.Tests.Property
 
 			property.Value.Should().Be(myValue);
 		}
-
-		[Theory]
-		[InlineData(true)]
-		[InlineData(false)]
-		public void It_Creates_Property_That_Throws_On_Set_When_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
-		{
-			// Arrange
-			var factory = new DynamicPropertyFactory(throwOnDisposed);
-
-			var taskProperty = factory.CreateFromTask(DefaultPropertyName, _ => Task.FromResult(new TestEntity()), new TestEntity());
-			var obProperty = factory.CreateFromObservable(DefaultPropertyName, new Subject<TestEntity>(), new TestEntity());
-			var property = factory.Create(DefaultPropertyName, new TestEntity());
-
-			// Act
-			taskProperty.Dispose();
-			obProperty.Dispose();
-			property.Dispose();
-
-			Action actTask = () =>
-			{
-				taskProperty.Value = new TestEntity();
-			};
-			Action actOb = () =>
-			{
-				obProperty.Value = new TestEntity();
-			};
-			Action actP = () =>
-			{
-				property.Value = new TestEntity();
-			};
-
-			// Assert
-			if (throwOnDisposed)
-			{
-				actTask.Should().Throw<InvalidOperationException>();
-				actOb.Should().Throw<InvalidOperationException>();
-				actP.Should().Throw<InvalidOperationException>();
-			}
-			else
-			{
-				actTask.Should().NotThrow();
-				actOb.Should().NotThrow();
-				actP.Should().NotThrow();
-			}
-		}
 	}
 }

--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.T.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.T.cs
@@ -79,14 +79,12 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			}
 		}
 
-		[Theory]
-		[InlineData(true)]
-		[InlineData(false)]
-		public void It_Throws_When_Value_Set_After_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
+		[Fact]
+		public void It_Doesnt_Throw_ObjectDisposedException_Upon_Setting_Value_While_Disposed()
 		{
 			// Arrange
 			var receivedValues = new List<IDynamicProperty>();
-			var property = new DynamicProperty<TestEntity>(DefaultPropertyName, throwOnDisposed: throwOnDisposed);
+			var property = new DynamicProperty<TestEntity>(DefaultPropertyName);
 
 			// Act
 			property.Dispose();
@@ -96,14 +94,22 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			};
 
 			// Assert
-			if (throwOnDisposed)
-			{
-				act.Should().Throw<ObjectDisposedException>();
-			}
-			else
-			{
-				act.Should().NotThrow();
-			}
+			act.Should().NotThrow();			
+		}
+
+		[Fact]
+		public void It_Doesnt_Change_Value_When_Disposed()
+		{
+			// Arrange
+			var myValue = new TestEntity();
+			var property = new DynamicProperty<TestEntity>(DefaultPropertyName, myValue);
+
+			// Act
+			property.Dispose();
+			property.Value = new TestEntity();
+
+			// Assert
+			property.Value.Should().Be(myValue);
 		}
 
 		[Fact]

--- a/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.cs
+++ b/src/DynamicMvvm.Tests/Property/DynamicPropertyTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Chinook.DynamicMvvm.Tests.Helpers;
 using FluentAssertions;
 using Xunit;
 
@@ -78,13 +79,12 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			}
 		}
 
-		[Theory]
-		[InlineData(true)]
-		[InlineData(false)]
-		public void It_Throws_When_Value_Set_After_Disposed_Only_If_ThrowOnDisposed_Is_True(bool throwOnDisposed)
+		[Fact]
+		public void It_Doesnt_Throw_ObjectDisposedException_Upon_Setting_Value_While_Disposed()
 		{
 			// Arrange
-			var property = new DynamicProperty(DefaultPropertyName, throwOnDisposed: throwOnDisposed);
+			var receivedValues = new List<IDynamicProperty>();
+			var property = new DynamicProperty(DefaultPropertyName);
 
 			// Act
 			property.Dispose();
@@ -94,24 +94,22 @@ namespace Chinook.DynamicMvvm.Tests.Property
 			};
 
 			// Assert
-			if (throwOnDisposed)
-			{
-				act.Should().Throw<ObjectDisposedException>();
-			}
-			else
-			{
-				act.Should().NotThrow();
-			}
+			act.Should().NotThrow();
 		}
 
 		[Fact]
-		public void It_Throws_When_Value_Set_After_Disposed()
+		public void It_Doesnt_Change_Value_When_Disposed()
 		{
-			var property = new DynamicProperty(DefaultPropertyName);
+			// Arrange
+			var myValue = new object();
+			var property = new DynamicProperty(DefaultPropertyName, myValue);
 
+			// Act
 			property.Dispose();
+			property.Value = new object();
 
-			Assert.Throws<ObjectDisposedException>(() => property.Value = new object());
+			// Assert
+			property.Value.Should().Be(myValue);
 		}
 
 		[Fact]

--- a/src/DynamicMvvm/LoggerMessages.cs
+++ b/src/DynamicMvvm/LoggerMessages.cs
@@ -61,6 +61,9 @@ namespace Chinook.DynamicMvvm
 		[LoggerMessage(31, LogLevel.Error, "Source task failed for property '{PropertyName}'.")]
 		public static partial void LogDynamicPropertySourceTaskFailed(this ILogger logger, string propertyName, Exception exception);
 
+		[LoggerMessage(32, LogLevel.Debug, "Skipped value setter on the property '{PropertyName}' because it's disposed.")]
+		public static partial void LogDynamicPropertySkippedValueSetterBecauseDisposed(this ILogger logger, string propertyName);
+
 		[LoggerMessage(40, LogLevel.Debug, "Deactivated observable source of property '{PropertyName}'.")]
 		public static partial void LogDeactivatedObservableSource(this ILogger logger, string propertyName);
 

--- a/src/DynamicMvvm/Property/DynamicProperty.T.cs
+++ b/src/DynamicMvvm/Property/DynamicProperty.T.cs
@@ -26,8 +26,9 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">Name</param>
 		/// <param name="value">Initial value</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public DynamicProperty(string name, bool throwOnDisposed, T value = default)
-			: base(name, throwOnDisposed, value)
+			: base(name, value)
 		{
 		}
 

--- a/src/DynamicMvvm/Property/DynamicProperty.cs
+++ b/src/DynamicMvvm/Property/DynamicProperty.cs
@@ -9,7 +9,6 @@ namespace Chinook.DynamicMvvm
 	public class DynamicProperty : IDynamicProperty
 	{
 		private static readonly DiagnosticSource _diagnostics = new DiagnosticListener("Chinook.DynamicMvvm.IDynamicProperty");
-		private readonly bool _throwOnDisposed;
 
 		private object _value;
 		private bool _isDisposed;
@@ -31,7 +30,6 @@ namespace Chinook.DynamicMvvm
 			{
 				_diagnostics.Write("Created", Name);
 			}
-			_throwOnDisposed = true;
 		}
 
 		/// <summary>
@@ -40,16 +38,10 @@ namespace Chinook.DynamicMvvm
 		/// <param name="name">Name</param>
 		/// <param name="value">Initial value</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public DynamicProperty(string name, bool throwOnDisposed, object value = default)
+			: this(name, value)
 		{
-			Name = name;
-			_value = value;
-
-			if (_diagnostics.IsEnabled("Created"))
-			{
-				_diagnostics.Write("Created", Name);
-			}
-			_throwOnDisposed = throwOnDisposed;
 		}
 
 		/// <inheritdoc />
@@ -63,14 +55,8 @@ namespace Chinook.DynamicMvvm
 			{
 				if (_isDisposed)
 				{
-					if (_throwOnDisposed)
-					{
-						throw new ObjectDisposedException(Name);
-					}
-					else
-					{
-						return;
-					}
+					this.Log().LogDynamicPropertySkippedValueSetterBecauseDisposed(Name);
+					return;					
 				}
 
 				if (!Equals(value, _value))

--- a/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFactory.cs
@@ -13,8 +13,6 @@ namespace Chinook.DynamicMvvm
 	[Preserve(AllMembers = true)]
 	public class DynamicPropertyFactory : IDynamicPropertyFactory
 	{
-		private readonly bool _throwOnDisposed;
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
 		/// </summary>
@@ -23,28 +21,27 @@ namespace Chinook.DynamicMvvm
 		/// </remarks>
 		public DynamicPropertyFactory()
 		{
-			_throwOnDisposed = true;
 		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
 		/// </summary>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public DynamicPropertyFactory(bool throwOnDisposed)
 		{
-			_throwOnDisposed = throwOnDisposed;
 		}
 
 		/// <inheritdoc />
 		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicProperty<T>(name, _throwOnDisposed, initialValue);
+			=> new DynamicProperty<T>(name, initialValue);
 
 		/// <inheritdoc />
 		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicPropertyFromTask<T>(name, source, _throwOnDisposed, initialValue);
+			=> new DynamicPropertyFromTask<T>(name, source, initialValue);
 
 		/// <inheritdoc />
 		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
-			=> new DynamicPropertyFromObservable<T>(name, source, _throwOnDisposed, initialValue);
+			=> new DynamicPropertyFromObservable<T>(name, source, initialValue);
 	}
 }

--- a/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromObservable.cs
@@ -43,16 +43,10 @@ namespace Chinook.DynamicMvvm
 		/// <param name="source">Source</param>
 		/// <param name="initialValue">Initial value</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public DynamicPropertyFromObservable(string name, IObservable<T> source, bool throwOnDisposed, T initialValue = default)
-			: base(name, throwOnDisposed, initialValue)
+			: this(name, source, initialValue)
 		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			_propertyObserver = new DynamicPropertyObserver(this);
-			_subscription = source.Subscribe(_propertyObserver);
 		}
 
 		/// <inheritdoc />

--- a/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/DynamicPropertyFromTask.cs
@@ -43,17 +43,10 @@ namespace Chinook.DynamicMvvm
 		/// <param name="source">Source</param>
 		/// <param name="initialValue">Initial value</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public DynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, bool throwOnDisposed, T initialValue = default)
-			: base(name, throwOnDisposed, initialValue)
+			: this(name, source, initialValue)
 		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			_cancellationTokenSource = new CancellationTokenSource();
-
-			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
 		}
 
 		private async Task SetValueFromSource(CancellationToken ct, Func<CancellationToken, Task<T>> source)

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicProperty.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicProperty.cs
@@ -11,7 +11,6 @@ namespace Chinook.DynamicMvvm.Implementations
 	{
 		private static readonly DiagnosticSource _diagnostics = new DiagnosticListener("Chinook.DynamicMvvm.IDynamicProperty");
 		private readonly WeakReference<IViewModel> _viewModel;
-		private readonly bool _throwOnDisposed;
 
 		private object _value;
 		private bool _isDisposed;
@@ -35,7 +34,6 @@ namespace Chinook.DynamicMvvm.Implementations
 			{
 				_diagnostics.Write("Created", Name);
 			}
-			_throwOnDisposed = true;
 		}
 
 		/// <summary>
@@ -45,17 +43,10 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="value">The initial value of this property.</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public ValueChangedOnBackgroundTaskDynamicProperty(string name, IViewModel viewModel, bool throwOnDisposed, object value = default)
+			: this(name, viewModel, value)
 		{
-			Name = name;
-			_viewModel = new WeakReference<IViewModel>(viewModel);
-			_value = value;
-
-			if (_diagnostics.IsEnabled("Created"))
-			{
-				_diagnostics.Write("Created", Name);
-			}
-			_throwOnDisposed = throwOnDisposed;
 		}
 
 		protected bool IsOnDispatcher => _viewModel.TryGetTarget(out var vm) && (vm.Dispatcher?.GetHasDispatcherAccess() ?? false);
@@ -71,14 +62,8 @@ namespace Chinook.DynamicMvvm.Implementations
 			{
 				if (_isDisposed)
 				{
-					if (_throwOnDisposed)
-					{
-						throw new ObjectDisposedException(Name);
-					}
-					else
-					{
-						return;
-					}
+					this.Log().LogDynamicPropertySkippedValueSetterBecauseDisposed(Name);
+					return;					
 				}
 
 				if (!Equals(value, _value))
@@ -174,8 +159,9 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="value">The initial value of this property.</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public ValueChangedOnBackgroundTaskDynamicProperty(string name, IViewModel viewModel, bool throwOnDisposed, T value = default)
-			: base(name, viewModel, throwOnDisposed, value)
+			: base(name, viewModel, value)
 		{
 		}
 

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFactory.cs
@@ -10,8 +10,6 @@ namespace Chinook.DynamicMvvm.Implementations
 	[Preserve(AllMembers = true)]
 	public class ValueChangedOnBackgroundTaskDynamicPropertyFactory : IDynamicPropertyFactory
 	{
-		private readonly bool _throwOnDisposed;
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
 		/// </summary>
@@ -20,34 +18,33 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// </remarks>
 		public ValueChangedOnBackgroundTaskDynamicPropertyFactory()
 		{
-			_throwOnDisposed = true;
 		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="DynamicPropertyFactory"/> class.
 		/// </summary>
 		/// <param name="throwOnDisposed">Whether a <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFactory"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public ValueChangedOnBackgroundTaskDynamicPropertyFactory(bool throwOnDisposed = true)
 		{
-			_throwOnDisposed = throwOnDisposed;
 		}
 
 		/// <inheritdoc/>
 		public virtual IDynamicProperty Create<T>(string name, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicProperty<T>(name, viewModel, _throwOnDisposed, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicProperty<T>(name, viewModel, initialValue);
 		}
 
 		/// <inheritdoc/>
 		public virtual IDynamicProperty CreateFromObservable<T>(string name, IObservable<T> source, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T>(name, source, viewModel, _throwOnDisposed, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromObservable<T>(name, source, viewModel, initialValue);
 		}
 
 		/// <inheritdoc/>
 		public virtual IDynamicProperty CreateFromTask<T>(string name, Func<CancellationToken, Task<T>> source, T initialValue = default, IViewModel viewModel = null)
 		{
-			return new ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T>(name, source, viewModel, _throwOnDisposed, initialValue);
+			return new ValueChangedOnBackgroundTaskDynamicPropertyFromTask<T>(name, source, viewModel, initialValue);
 		}
 	}
 }

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromObservable.cs
@@ -42,16 +42,10 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="initialValue">The initial value of this property.</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public ValueChangedOnBackgroundTaskDynamicPropertyFromObservable(string name, IObservable<T> source, IViewModel viewModel, bool throwOnDisposed, T initialValue = default)
-			: base(name, viewModel, throwOnDisposed, initialValue)
+			: this(name, source, viewModel, initialValue)
 		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			_propertyObserver = new DynamicPropertyFromObservable<T>.DynamicPropertyObserver(this);
-			_subscription = source.Subscribe(_propertyObserver);
 		}
 
 		/// <inheritdoc />

--- a/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
+++ b/src/DynamicMvvm/Property/ValueChangedOnBackgroundTask/ValueChangedOnBackgroundTaskDynamicPropertyFromTask.cs
@@ -45,17 +45,10 @@ namespace Chinook.DynamicMvvm.Implementations
 		/// <param name="viewModel">The <see cref="IViewModel"/> used to determine dispatcher access.</param>
 		/// <param name="initialValue">The initial value of this property.</param>
 		/// <param name="throwOnDisposed">Whether a <see cref="ObjectDisposedException"/> should be thrown when <see cref="IDynamicProperty.Value"/> is changed after being disposed.</param>
+		[Obsolete("This constructor is obsolete. The throwOnDisposed parameter is no longer used.", error: false)]
 		public ValueChangedOnBackgroundTaskDynamicPropertyFromTask(string name, Func<CancellationToken, Task<T>> source, IViewModel viewModel, bool throwOnDisposed, T initialValue = default)
-			: base(name, viewModel, throwOnDisposed, initialValue)
+			: this(name, source, viewModel, initialValue)
 		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			_cancellationTokenSource = new CancellationTokenSource();
-
-			_ = SetValueFromSource(_cancellationTokenSource.Token, source);
 		}
 
 		private async Task SetValueFromSource(CancellationToken ct, Func<CancellationToken, Task<T>> source)


### PR DESCRIPTION
GitHub Issue:
Fixes #90 
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- Setting the `Value` property of a `DynamicProperty` while it is disposed throws an `ObjectDisposedException`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- Setting the `Value` property of a `DynamicProperty` while it is disposed logs a debug message.
- All overloads using a `throwOnDisposed` parameters are marked as obsolete.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

