### PR TITLE
perf: Make ViewModelBase's internal errors dictionary lazy initialized

### DIFF
--- a/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseErrorsTests.cs
+++ b/src/DynamicMvvm.Tests/ViewModel/ViewModelBaseErrorsTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Chinook.DynamicMvvm.Tests.ViewModel
+{
+	public class ViewModelBaseErrorsTests
+	{
+		[Fact]
+		public void It_Has_No_Errors_By_Default()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+
+			// Assert
+			sut.HasErrors.Should().BeFalse();
+			sut.GetErrors(null).Should().BeEmpty();
+			sut.GetErrors("FakeProperty").Should().BeEmpty();
+		}
+
+		[Fact]
+		public void It_Can_Set_Errors_For_A_Property()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+
+			// Act
+			sut.SetErrors("Foo", new[] { "Bar" });
+
+			// Assert
+			sut.HasErrors.Should().BeTrue();
+			sut.GetErrors("Foo").Should().ContainEquivalentOf("Bar");
+		}
+
+		[Fact]
+		public void It_Can_Set_Errors_Using_Dictionary()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+
+			// Act
+			sut.SetErrors(new Dictionary<string, IEnumerable<object>>()
+			{
+				{ "Foo", new[] { "Bar" } }
+			});
+
+			// Assert
+			sut.HasErrors.Should().BeTrue();
+			sut.GetErrors(null).Should().ContainEquivalentOf("Bar");
+		}
+
+		[Fact]
+		public void It_Can_Clear_Errors_For_A_Property()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+
+			sut.SetErrors("Prop1", new[] { "Error1" });
+			sut.SetErrors("Prop2", new[] { "Error2" });
+
+			// Act
+			sut.ClearErrors("Prop1");
+
+			// Assert
+			sut.HasErrors.Should().BeTrue();
+			sut.GetErrors(null).Should().ContainEquivalentOf("Error2");
+		}
+
+		[Fact]
+		public void It_Can_Clear_Errors_For_All_Properties()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+
+			sut.SetErrors("Prop1", new[] { "Error1" });
+			sut.SetErrors("Prop2", new[] { "Error2" });
+
+			// Act
+			sut.ClearErrors();
+
+			// Assert
+			sut.HasErrors.Should().BeFalse();
+			sut.GetErrors(null).Should().BeEmpty();
+		}
+
+		[Fact]
+		public void It_Raises_ErrorsChanged_When_Errors_Are_Set()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+			var receivedValues = new List<(object, DataErrorsChangedEventArgs)>();
+
+			sut.ErrorsChanged += OnErrorsChanged;
+
+			// Act
+			sut.SetErrors("Foo", new[] { "Bar" });
+
+			// Assert
+			receivedValues.Count().Should().Be(1);
+			receivedValues[0].Item1.Should().Be(sut);
+			receivedValues[0].Item2.PropertyName.Should().Be("Foo");
+
+			void OnErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+			{
+				receivedValues.Add((sender, e));
+			}
+		}
+
+		[Fact]
+		public void It_Raises_ErrorsChanged_When_Errors_Are_Cleared()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+			var receivedValues = new List<(object, DataErrorsChangedEventArgs)>();
+
+			sut.SetErrors("Foo", new[] { "Bar" });
+			sut.ErrorsChanged += OnErrorsChanged;
+
+			// Act
+			sut.ClearErrors("Foo");
+
+			// Assert
+			receivedValues.Count().Should().Be(1);
+			receivedValues[0].Item1.Should().Be(sut);
+			receivedValues[0].Item2.PropertyName.Should().Be("Foo");
+
+			void OnErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+			{
+				receivedValues.Add((sender, e));
+			}
+		}
+
+		[Fact]
+		public void It_Raises_ErrorsChanged_When_Errors_Are_Cleared_For_All_Properties()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+			var receivedValues = new List<(object, DataErrorsChangedEventArgs)>();
+
+			sut.SetErrors("Foo", new[] { "Bar" });
+			sut.ErrorsChanged += OnErrorsChanged;
+
+			// Act
+			sut.ClearErrors();
+
+			// Assert
+			receivedValues.Count().Should().Be(1);
+			receivedValues[0].Item1.Should().Be(sut);
+			receivedValues[0].Item2.PropertyName.Should().BeNull();
+
+			void OnErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+			{
+				receivedValues.Add((sender, e));
+			}
+		}
+
+		[Fact]
+		public void Clear_Doesnt_Raise_ErrorsChanged_There_Are_No_Errors()
+		{
+			// Arrange
+			var sut = new ViewModelBase();
+			var receivedValues = new List<(object, DataErrorsChangedEventArgs)>();
+
+			sut.ErrorsChanged += OnErrorsChanged;
+
+			// Act
+			sut.ClearErrors();
+
+			// Assert
+			receivedValues.Should().BeEmpty();
+
+			void OnErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+			{
+				receivedValues.Add((sender, e));
+			}
+		}
+	}
+}

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Errors.cs
@@ -11,13 +11,13 @@ namespace Chinook.DynamicMvvm
 {
 	public partial class ViewModelBase
 	{
-		private ConcurrentDictionary<string, IEnumerable<object>> _errors = new ConcurrentDictionary<string, IEnumerable<object>>();
+		private Dictionary<string, IEnumerable<object>> _errors;
 
 		/// <inheritdoc />
 		public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
 
 		/// <inheritdoc />
-		public bool HasErrors => _errors.Values.SelectMany(x => x).Any();
+		public bool HasErrors => _errors is null ? false : _errors.Values.SelectMany(x => x).Any();
 
 		/// <inheritdoc />
 		public IEnumerable GetErrors(string propertyName)
@@ -27,12 +27,12 @@ namespace Chinook.DynamicMvvm
 			if (string.IsNullOrEmpty(propertyName))
 			{
 				// Entity level errors.
-				errors = _errors.Values.SelectMany(s => s);
+				errors = _errors?.Values.SelectMany(s => s);
 			}
 			else
 			{
 				// Property level errors.
-				_errors.TryGetValue(propertyName, out errors);
+				_errors?.TryGetValue(propertyName, out errors);
 			}
 
 			return errors ?? Enumerable.Empty<object>();
@@ -49,6 +49,7 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
+			EnsureErrorsAreInitialized();
 			_errors[propertyName] = errors;
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
@@ -65,7 +66,7 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
-			_errors = new ConcurrentDictionary<string, IEnumerable<object>>(errors);
+			_errors = new Dictionary<string, IEnumerable<object>>(errors);
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName: null));
 		}
@@ -81,6 +82,12 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
+			if (_errors is null)
+			{
+				// No errors to clear.
+				return;
+			}
+
 			if (string.IsNullOrEmpty(propertyName))
 			{
 				_errors.Clear();
@@ -91,6 +98,14 @@ namespace Chinook.DynamicMvvm
 			}
 
 			ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+		}
+
+		private void EnsureErrorsAreInitialized()
+		{
+			if (_errors is null)
+			{
+				_errors = new Dictionary<string, IEnumerable<object>>();
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe: Performance optimization

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- The internal `_errors` dictionary for the `INotifyDataErrorInfo` aspect of `ViewModelBase` is always instantiated, even if the `INotifyDataErrorInfo` features aren't used for a ViewModel.
- The `_errors` dictionary is a `ConcurrentDictionary`.

| Method                              | Mean      | Allocated |
|------------------------------------ |----------:|----------:|
| CreateViewModel                     |  2.057 μs |    1760 B |
| CreateViewModel_WithExplicitName    |  2.077 μs |    1760 B |

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- The `_errors` field is now a `Dictionary`. We weren't using any features specific to `ConcurrentDictionary`.
- The `_errors` field is now lazy-initialized. It stays `null` as long a we don't call `SetErrors`.

| Method                              | Mean      | Allocated |
|------------------------------------ |----------:|----------:|
| CreateViewModel                     |  1.280 μs |     936 B |
| CreateViewModel_WithExplicitName    |  1.193 μs |     936 B |

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

