### PR TITLE
fix: Don't throw ObjectDisposedException when calling RaisePropertyCh…

### DIFF
--- a/src/DynamicMvvm.Tests/Integration/IntegrationTests.cs
+++ b/src/DynamicMvvm.Tests/Integration/IntegrationTests.cs
@@ -110,7 +110,23 @@ namespace Chinook.DynamicMvvm.Tests.Integration
 			Assert.Throws<ObjectDisposedException>(() => viewModel.SetErrors(errors: new Dictionary<string, IEnumerable<object>>()));
 			Assert.Throws<ObjectDisposedException>(() => viewModel.ClearErrors(nameof(MyViewModel.Counter)));
 			Assert.Throws<ObjectDisposedException>(() => viewModel.Dispatcher = new TestDispatcher());
-			Assert.Throws<ObjectDisposedException>(() => viewModel.RaisePropertyChanged(nameof(MyViewModel.Counter)));
+		}
+
+		[Fact]
+		public void A_disposed_VM_does_not_raise_PropertyChanged()
+		{
+			// Arrange
+			var viewModel = new MyViewModel(_serviceProvider);
+
+			var raised = false;
+			viewModel.PropertyChanged += (s, e) => raised = true;
+
+			// Act
+			viewModel.Dispose();
+			viewModel.Counter++;
+
+			// Assert
+			raised.Should().BeFalse();
 		}
 
 		[Fact]

--- a/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.PropertyChanged.cs
@@ -13,11 +13,15 @@ namespace Chinook.DynamicMvvm
 		/// <inheritdoc />
 		public virtual void RaisePropertyChanged(string propertyName)
 		{
-			ThrowIfDisposed();
-
 			if (_isDisposing)
 			{
 				_logger.LogViewModelSkippedMethodBecauseDisposing_PropertyName(nameof(RaisePropertyChanged), GetType().Name, propertyName, Name);
+				return;
+			}
+
+			if (_isDisposed)
+			{
+				_logger.LogViewModelSkippedMethodBecauseDisposed_PropertyName(nameof(RaisePropertyChanged), GetType().Name, propertyName, Name);
 				return;
 			}
 


### PR DESCRIPTION
…anged on a disposed VM to align with the RaisePropertyChangedInner behavior.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

An `ObjectDisposedException` is thrown when invoking `RaisePropertyChanged` on a disposed `ViewModelBase`.
No `ObjectDisposedException` is thrown when invoking `RaisePropertyChangedInner` on a disposed `ViewModelBase`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

No `ObjectDisposedException` is thrown when invoking any of `RaisePropertyChanged` or `RaisePropertyChangedInner` on a disposed `ViewModelBase`.
Note however that a debug-level log message is triggered in both cases.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.
  - Only code in the Benchmarks project was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

