### PR TITLE
Fix disposables management for thread-safe operations

### DIFF
--- a/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
+++ b/src/DynamicMvvm/ViewModel/ViewModelBase.Disposable.cs
@@ -1,16 +1,14 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using Microsoft.Extensions.Logging;
 
 namespace Chinook.DynamicMvvm
 {
 	public partial class ViewModelBase
 	{
-		private readonly Dictionary<string, IDisposable> _disposables = new Dictionary<string, IDisposable>();
-		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+		private readonly ConcurrentDictionary<string, IDisposable> _disposables = new();
+		private readonly CancellationTokenSource _cts = new();
 
 		private bool _isDisposing;
 		private bool _isDisposed;
@@ -47,7 +45,7 @@ namespace Chinook.DynamicMvvm
 				return;
 			}
 
-			_disposables.Add(key, disposable);
+			_disposables.TryAdd(key, disposable);
 		}
 
 		/// <inheritdoc />
@@ -63,7 +61,7 @@ namespace Chinook.DynamicMvvm
 
 			ThrowIfDisposed();
 
-			_disposables.Remove(key);
+			_disposables.TryRemove(key, out _);
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
GitHub Issue: #105
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
Adding or removing a disposable could result in an InvalidOperationException in a muti threaded context.


## What is the new behavior?
Enumerating disposables while adding or removing is now thread-safe.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.
  - Only code in the Benchmarks project was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [x] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [ ] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

